### PR TITLE
Support for default system proxy settings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@ int main(int argc, char *argv[])
     QObject::connect(tray, SIGNAL(closeEventTriggered()), &app, SLOT(quit()));
 
     //Prime network manager
+    QNetworkProxyFactory::setUseSystemConfiguration(true);
     NetworkManager *netman = new NetworkManager(engine.networkAccessManager());
 
     //Create channels manager


### PR DESCRIPTION
Orion is lacking proxy support. This is basic support for system proxy settings applied to the application.