### PR TITLE
reduce QTQuick.Controls dependency to 2.0 for qt 5.7 compatibility

### DIFF
--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -13,7 +13,7 @@
  */
 
 import QtQuick 2.5
-import QtQuick.Controls 2.1
+import QtQuick.Controls 2.0
 import "components"
 import "irc"
 import "styles.js" as Styles


### PR DESCRIPTION
Fixes the problem with https://github.com/alamminsalo/orion/issues/65 -- openSUSE Tumbleweed only has QtQuick.Controls 2.0