### PR TITLE
Add a way to open chat for offline channels; channel views refactoring

### DIFF
--- a/src/qml/FavouritesView.qml
+++ b/src/qml/FavouritesView.qml
@@ -33,7 +33,8 @@ Item{
 
     ChannelGrid {
         id: favourites
-        tooltipEnabled: true
+
+        allFavourites: true
 
         anchors {
             top: header.bottom
@@ -44,55 +45,6 @@ Item{
         }
 
         model: g_favourites
-        delegate: Channel {
-            _id: model.id
-            name: model.serviceName
-            title: model.name
-            logo: model.logo
-            info: model.info
-            viewers: model.viewers
-            preview: model.preview
-            online: model.online
-            game: model.game
-        }
-
-        onItemClicked: {
-            if (currentItem.online){
-                playerView.getStreams(currentItem)
-            }
-        }
-
-        onItemRightClicked: {
-            _menu.item = currentItem
-            _menu.items[0].enabled = _menu.item.online
-            _menu.popup()
-        }
-
-        ContextMenu {
-            id: _menu
-            MenuItem {
-                //text: "Watch;play"
-                text: "Watch live"
-                onTriggered: {
-                    if (_menu.item.online){
-                        playerView.getStreams(_menu.item)
-                    }
-                }
-            }
-            MenuItem {
-                //text: "Videos;video"
-                text: "Past broadcasts"
-                onTriggered: {
-                    vodsView.search(_menu.item)
-                }
-            }
-            MenuItem {
-                text: "Unfollow"
-                onTriggered: {
-                    g_cman.removeFromFavourites(_menu.item._id)
-                }
-            }
-        }
     }
 }
 

--- a/src/qml/FeaturedView.qml
+++ b/src/qml/FeaturedView.qml
@@ -29,7 +29,6 @@ Item {
         property bool checked: false
 
         id: featured
-        tooltipEnabled: true
 
         anchors {
             top: header.bottom
@@ -48,73 +47,6 @@ Item {
         }
 
         model: g_featured
-        delegate: Channel {
-            _id: model.id
-            name: model.serviceName
-            title: model.name
-            logo: model.logo
-            info: model.info
-            viewers: model.viewers
-            preview: model.preview
-            online: model.online
-            game: model.game
-            favourite: model.favourite
-        }
-
-        onItemClicked: {
-            if (currentItem.online){
-                playerView.getStreams(currentItem)
-            }
-        }
-
-        onItemRightClicked: {
-            _menu.item = currentItem
-            _menu.items[0].enabled = _menu.item.online
-            var item = _menu.items[2]
-            item.text = !_menu.item.favourite ? "Follow" : "Unfollow"
-            _menu.state = !_menu.item.favourite ? 1 : 2
-
-            _menu.popup()
-        }
-
-        ContextMenu {
-            id: _menu
-
-            function addRemoveFavourite(){
-                if (state === 1){
-                    g_cman.addToFavourites(_menu.item._id)
-                } else if (state === 2){
-                    g_cman.removeFromFavourites(_menu.item._id)
-                }
-            }
-
-            MenuItem {
-                text: "Watch live"
-                //text: "Watch;play"
-                onTriggered: {
-                    if (_menu.item.online){
-                        playerView.getStreams(_menu.item)
-                    }
-                }
-            }
-
-            MenuItem {
-                text: "Past broadcasts"
-                //text: "Videos;video"
-                onTriggered: {
-                    vodsView.search(_menu.item)
-                }
-            }
-
-            MenuItem {
-                id: _fav
-                onTriggered: {
-                    _menu.addRemoveFavourite()
-                }
-            }
-
-
-        }
 
         Timer {
             id: timer

--- a/src/qml/GamesView.qml
+++ b/src/qml/GamesView.qml
@@ -173,7 +173,7 @@ Item {
         }
     }
 
-    ChannelGrid {
+    CommonGrid {
         id: games
         tooltipEnabled: true
 

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -148,6 +148,17 @@ Item {
     }
 
     function getStreams(channel, vod){
+        getChannel(channel, vod, true);
+    }
+
+    function getChat(channel) {
+        getChannel(channel, null, false);
+        if (chatview.status == 0) {
+            chatview.status++;
+        }
+    }
+
+    function getChannel(channel, vod, wantVideo){
 
         if (!channel){
             return
@@ -155,21 +166,23 @@ Item {
 
         renderer.stop()
 
-        if (!vod || typeof vod === "undefined") {
-            g_cman.findPlaybackStream(channel.name)
-            isVod = false
+        if (wantVideo) {
+            if (!vod || typeof vod === "undefined") {
+                g_cman.findPlaybackStream(channel.name)
+                isVod = false
 
-            duration = -1
-        }
-        else {
-            g_vodmgr.getBroadcasts(vod._id)
-            isVod = true
+                duration = -1
+            }
+            else {
+                g_vodmgr.getBroadcasts(vod._id)
+                isVod = true
 
-            duration = vod.duration
+                duration = vod.duration
 
-            console.log("Setting up VOD, duration " + vod.duration)
+                console.log("Setting up VOD, duration " + vod.duration)
 
-            seekBar.setPosition(0, duration)
+                seekBar.setPosition(0, duration)
+            }
         }
 
         currentChannel = {

--- a/src/qml/SearchView.qml
+++ b/src/qml/SearchView.qml
@@ -178,7 +178,6 @@ Item {
 
     ChannelGrid {
         id: channels
-        tooltipEnabled: true
 
         anchors {
             top: searchContainer.bottom
@@ -189,18 +188,6 @@ Item {
         }
 
         model: g_results
-        delegate: Channel {
-            _id: model.id
-            name: model.serviceName
-            title: model.name
-            logo: model.logo
-            info: model.info
-            viewers: model.viewers
-            preview: model.preview
-            online: model.online
-            game: model.game
-            favourite: model.favourite
-        }
 
         function checkScrolled(){
             if (atYEnd && model.count() === itemCount && itemCount > 0){
@@ -212,61 +199,6 @@ Item {
         onAtYEndChanged: {
             if (visible)
                 checkScrolled()
-        }
-
-        onItemClicked: {
-            if (currentItem.online){
-                playerView.getStreams(currentItem)
-            }
-        }
-
-        onItemRightClicked: {
-            _menu.item = currentItem
-
-            _menu.items[0].enabled = _menu.item.online
-
-            var item = _menu.items[2]
-            item.text = !_menu.item.favourite ? "Follow" : "Unfollow"
-            _menu.state = !_menu.item.favourite ? 1 : 2
-
-            _menu.popup()
-        }
-
-        ContextMenu {
-            id: _menu
-
-            function addRemoveFavourite(){
-                if (state === 1){
-                    g_cman.addToFavourites(_menu.item._id)
-                } else if (state === 2){
-                    g_cman.removeFromFavourites(_menu.item._id, _menu.item.title)
-                }
-            }
-
-            MenuItem {
-                text: "Watch live"
-                //text: "Watch;play"
-                onTriggered: {
-                    if (_menu.item.online){
-                        playerView.getStreams(_menu.item)
-                    }
-                }
-            }
-
-            MenuItem {
-                text: "Past broadcasts"
-                //text: "Videos;video"
-                onTriggered: {
-                    vodsView.search(_menu.item)
-                }
-            }
-
-            MenuItem {
-                id: _fav
-                onTriggered: {
-                    _menu.addRemoveFavourite()
-                }
-            }
         }
 
         Text {

--- a/src/qml/components/ChannelGrid.qml
+++ b/src/qml/components/ChannelGrid.qml
@@ -12,153 +12,89 @@
  * along with Orion.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQuick.Controls 1.4
 import QtQuick 2.5
 
-//ChannelList.qml
-GridView {
-    property variant selectedItem
-    property bool tooltipEnabled: false
-    property string title
+CommonGrid {
+    property bool allFavourites : false
 
-    signal itemClicked(int index)
-    signal itemRightClicked(int index)
+    tooltipEnabled: true
 
-    id: root
-
-    highlightFollowsCurrentItem: false
-    cellHeight: dp(200)
-    maximumFlickVelocity: 800
-    cellWidth: cellHeight
-
-    add: Transition {
-        NumberAnimation {
-            properties: "y"
-            from: contentY-200
-            duration: 200
-            easing.type: Easing.OutCubic
-        }
-    }
-
-    remove: Transition {
-        NumberAnimation {
-            property: "opacity"
-            to: 0
-            duration: 200
-            easing.type: Easing.OutCubic
-        }
-    }
-
-    function setFocus(){
-
-        if (mArea.containsMouse) {
-            root.currentIndex = indexAt(contentX + mArea.mouseX, contentY + mArea.mouseY)
-            if (tooltipEnabled)
-                tooltipTimer.restart()
-
+    onItemClicked: {
+        if (currentItem.online){
+            playerView.getStreams(currentItem)
         } else {
-            g_tooltip.hide()
+            playerView.getChat(currentItem)
         }
     }
 
-    function getMouseCoords(){
-        var mX = mArea.mouseX
-        var mY = mArea.mouseY
-        var p = mArea.parent
+    onItemRightClicked: {
+        _menu.item = currentItem
 
-        //Traverse dom tree to root, adding x,y-values from objects
-        while (p){
-            mX += p.x
-            mY += p.y
-            p = p.parent
-        }
-        return {x: mX, y: mY}
+        _watchLive.enabled = _menu.item.online
+
+        _fav.text = (!allFavourites && !_menu.item.favourite) ? "Follow" : "Unfollow"
+        _menu.state = (!allFavourites && !_menu.item.favourite) ? 1 : 2
+
+        _menu.popup()
     }
 
-    onContentYChanged: setFocus()
-    onContentXChanged: setFocus()
+    ContextMenu {
+        id: _menu
 
-    onSelectedItemChanged: {
-        if (g_tooltip)
-            g_tooltip.hide()
-        tooltipTimer.stop()
-    }
-
-    MouseArea{
-        id: mArea
-        anchors.fill: parent
-        hoverEnabled: true
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
-
-        onPositionChanged: setFocus()
-
-        onHoveredChanged: {
-            if (!containsMouse){
-                g_tooltip.hide()
-                tooltipTimer.stop()
+        function addRemoveFavourite(){
+            if (state === 1){
+                g_cman.addToFavourites(_menu.item._id)
+            } else if (state === 2){
+                g_cman.removeFromFavourites(_menu.item._id)
             }
         }
 
-        Timer {
-            id: tooltipTimer
-            interval: 800
-            running: false
-            repeat: false
+        MenuItem {
+            id: _watchLive
+            text: "Watch live"
+            //text: "Watch;play"
             onTriggered: {
-                if (tooltipEnabled){
-                    g_tooltip.hide()
-
-                    var mouseCoords = getMouseCoords()
-                    var mX = mouseCoords.x
-                    var mY = mouseCoords.y
-
-                    var index = root.indexAt(mX + root.contentX, mY + root.contentY)
-
-                    if (mArea.containsMouse && selectedItem && selectedItem.online){
-
-                        g_tooltip.text = ""
-
-                        if (selectedItem.game){
-                            g_tooltip.text += "Playing <b>" + selectedItem.game + "</b>"
-                        } else if (selectedItem.title){
-                            g_tooltip.text += selectedItem.title
-                        }
-
-                        if (selectedItem.viewers){
-                            g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
-                            g_tooltip.text += selectedItem.viewers + " viewers"
-                        }
-
-                        if (selectedItem.info){
-                            g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
-                            g_tooltip.text += selectedItem.info
-                        }
-
-                        g_tooltip.img = selectedItem.preview
-                        g_tooltip.display(g_rootWindow.x + mX, g_rootWindow.y + mY)
-                    }
+                if (_menu.item.online){
+                    playerView.getStreams(_menu.item)
                 }
             }
         }
 
-        onClicked: {
-            if (currentItem){
-                if (mouse.button === Qt.LeftButton)
-                    itemClicked(currentIndex)
-                else if (mouse.button === Qt.RightButton){
-                    itemRightClicked(currentIndex)
-                }
+        MenuItem {
+            text: "Past broadcasts"
+            //text: "Videos;video"
+            onTriggered: {
+                vodsView.search(_menu.item)
+            }
+        }
+
+        MenuItem {
+            text: "Open chat"
+            onTriggered: {
+                playerView.getChat(_menu.item);
+            }
+        }
+
+        MenuItem {
+            id: _fav
+            onTriggered: {
+                _menu.addRemoveFavourite()
             }
         }
     }
 
-    onCurrentItemChanged: {
-        if (selectedItem && typeof selectedItem.setHighlight === 'function')
-            selectedItem.setHighlight(false)
-
-        selectedItem = currentItem
-
-        if (selectedItem && typeof selectedItem.setHighlight === 'function'){
-            selectedItem.setHighlight(true)
-        }
+    delegate: Channel {
+        _id: model.id
+        name: model.serviceName
+        title: model.name
+        logo: model.logo
+        info: model.info
+        viewers: model.viewers
+        preview: model.preview
+        online: model.online
+        game: model.game
+        favourite: model.favourite
     }
+
 }

--- a/src/qml/components/CommonGrid.qml
+++ b/src/qml/components/CommonGrid.qml
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2015-2016 Antti Lamminsalo
+ *
+ * This file is part of Orion.
+ *
+ * Orion is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orion.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.5
+
+//ChannelList.qml
+GridView {
+    property variant selectedItem
+    property bool tooltipEnabled: false
+    property string title
+
+    signal itemClicked(int index)
+    signal itemRightClicked(int index)
+
+    id: root
+
+    highlightFollowsCurrentItem: false
+    cellHeight: dp(200)
+    maximumFlickVelocity: 800
+    cellWidth: cellHeight
+
+    add: Transition {
+        NumberAnimation {
+            properties: "y"
+            from: contentY-200
+            duration: 200
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    remove: Transition {
+        NumberAnimation {
+            property: "opacity"
+            to: 0
+            duration: 200
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    function setFocus(){
+
+        if (mArea.containsMouse) {
+            root.currentIndex = indexAt(contentX + mArea.mouseX, contentY + mArea.mouseY)
+            if (tooltipEnabled)
+                tooltipTimer.restart()
+
+        } else {
+            g_tooltip.hide()
+        }
+    }
+
+    function getMouseCoords(){
+        var mX = mArea.mouseX
+        var mY = mArea.mouseY
+        var p = mArea.parent
+
+        //Traverse dom tree to root, adding x,y-values from objects
+        while (p){
+            mX += p.x
+            mY += p.y
+            p = p.parent
+        }
+        return {x: mX, y: mY}
+    }
+
+    onContentYChanged: setFocus()
+    onContentXChanged: setFocus()
+
+    onSelectedItemChanged: {
+        if (g_tooltip)
+            g_tooltip.hide()
+        tooltipTimer.stop()
+    }
+
+    MouseArea{
+        id: mArea
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+        onPositionChanged: setFocus()
+
+        onHoveredChanged: {
+            if (!containsMouse){
+                g_tooltip.hide()
+                tooltipTimer.stop()
+            }
+        }
+
+        Timer {
+            id: tooltipTimer
+            interval: 800
+            running: false
+            repeat: false
+            onTriggered: {
+                if (tooltipEnabled){
+                    g_tooltip.hide()
+
+                    var mouseCoords = getMouseCoords()
+                    var mX = mouseCoords.x
+                    var mY = mouseCoords.y
+
+                    var index = root.indexAt(mX + root.contentX, mY + root.contentY)
+
+                    if (mArea.containsMouse && selectedItem && selectedItem.online){
+
+                        g_tooltip.text = ""
+
+                        if (selectedItem.game){
+                            g_tooltip.text += "Playing <b>" + selectedItem.game + "</b>"
+                        } else if (selectedItem.title){
+                            g_tooltip.text += selectedItem.title
+                        }
+
+                        if (selectedItem.viewers){
+                            g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
+                            g_tooltip.text += selectedItem.viewers + " viewers"
+                        }
+
+                        if (selectedItem.info){
+                            g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
+                            g_tooltip.text += selectedItem.info
+                        }
+
+                        g_tooltip.img = selectedItem.preview
+                        g_tooltip.display(g_rootWindow.x + mX, g_rootWindow.y + mY)
+                    }
+                }
+            }
+        }
+
+        onClicked: {
+            if (currentItem){
+                if (mouse.button === Qt.LeftButton)
+                    itemClicked(currentIndex)
+                else if (mouse.button === Qt.RightButton){
+                    itemRightClicked(currentIndex)
+                }
+            }
+        }
+    }
+
+    onCurrentItemChanged: {
+        if (selectedItem && typeof selectedItem.setHighlight === 'function')
+            selectedItem.setHighlight(false)
+
+        selectedItem = currentItem
+
+        if (selectedItem && typeof selectedItem.setHighlight === 'function'){
+            selectedItem.setHighlight(true)
+        }
+    }
+}

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -2,7 +2,6 @@
     <qresource prefix="/">
         <file>main.qml</file>
         <file>components/Channel.qml</file>
-        <file>components/ChannelGrid.qml</file>
         <file>components/Tooltip.qml</file>
         <file>styles.js</file>
         <file>components/PurpleButton.qml</file>
@@ -54,5 +53,7 @@
         <file>irc/ChatMessage.qml</file>
         <file>MpvBackend.qml</file>
         <file>IconButton.qml</file>
+        <file>components/CommonGrid.qml</file>
+        <file>components/ChannelGrid.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This started out as something to facilitate chat testing for the emote support work but it seems like it could be useful for regular users as well

- Renamed the previous ChannelGrid to CommonGrid and refactored common channel views' (FavouritesView, FeaturedView, SearchView) grid components into a new ChannelGrid layer
- Added "Open Chat" command to ChannelGrid's context menu; it goes to player view and opens channel chat without starting playback
- **Made a normal click on an offline channel in a channel view also open chat**