### PR TITLE
Twitch Emotes & Badges Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Features:
 ####Install needed libraries and software
 
 ```
-sudo pacman -S git gcc qt5-base qt5-quickcontrols qt5-svg qt5-webengine mpv
+sudo pacman -S git gcc qt5-base qt5-quickcontrols qt5-svg qt5-webengine qt5-quickcontrols2 mpv
 ```
 
 If using backend other than mpv, install those packages instead.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-#Orion
+# Orion
 
 QML/C++-written desktop client for Twitch.tv
 
@@ -11,7 +11,7 @@ Features:
 * Chat support
 * Support for live streams and vods
 
-##Screencaptures
+## Screencaptures
 
 ![alt tag](https://raw.githubusercontent.com/alamminsalo/orion/master/resources/screenshots/7.png)
 
@@ -19,15 +19,15 @@ Features:
 
 ![alt tag](https://raw.githubusercontent.com/alamminsalo/orion/master/resources/screenshots/8.jpeg)
 
-##Dependencies
+## Dependencies
 
 * `mpv` (default), `qtav` or `qt5-multimedia`
 
-##Building on linux
+## Building on linux
 
 (Using arch linux examples, but can be applied to other distros as well)
 
-####Install needed libraries and software
+#### Install needed libraries and software
 
 ```
 sudo pacman -S git gcc qt5-base qt5-quickcontrols qt5-svg qt5-webengine qt5-quickcontrols2 mpv
@@ -35,7 +35,7 @@ sudo pacman -S git gcc qt5-base qt5-quickcontrols qt5-svg qt5-webengine qt5-quic
 
 If using backend other than mpv, install those packages instead.
 
-####Choosing player backend (optional)
+#### Choosing player backend (optional)
 To select a backend used, pass CONFIG-variable a suitable backend for qmake (alternatively edit straight to .pro file):
 
 * MPV: `CONFIG+=mpv`
@@ -44,7 +44,7 @@ To select a backend used, pass CONFIG-variable a suitable backend for qmake (alt
 
 As default, mpv is used (if nothing is passed)
 
-####Get orion from github and install
+#### Get orion from github and install
 
 ```
 git clone https://github.com/alamminsalo/orion
@@ -54,13 +54,13 @@ qmake ../
 make && sudo make install
 ```
 
-##Windows troubleshooting
+## Windows troubleshooting
 
 You need Visual C++ 2015-runtime installed. 
 
 Installer can be found in the application's install directory (I'll make it install automatically in the next version)
 
-##Known issues
+## Known issues
 
 * If network goes down while Orion is running, the images stop loading until application restart. Otherwise the application should work fine after network is back up
 * Sometimes the stream hangs and doesn't load on start. Restarting the stream should work

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -391,6 +391,7 @@ void ChannelManager::checkStreams(const QList<Channel *> &list)
     if (list.size() == 0)
         return;
 
+	int overall_index = 0;
     int c_index = 0;
     QString channelsUrl = "";
 
@@ -399,7 +400,7 @@ void ChannelManager::checkStreams(const QList<Channel *> &list)
             channelsUrl += ",";
         channelsUrl += channel->getServiceName();
 
-        if (c_index >= list.size() || c_index >= 50){
+        if (++overall_index >= list.size() || c_index >= 50){
             QString url = KRAKEN_API
                     + QString("/streams?limit=%1&channel=").arg(c_index)
                     + channelsUrl;

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -388,28 +388,32 @@ void ChannelManager::removeFromFavourites(const quint32 &id){
 
 void ChannelManager::checkStreams(const QList<Channel *> &list)
 {
-    if (list.size() == 0)
-        return;
+    //Divide list to sublists for sanity
+    int pos = 0;
 
-    int overall_index = 0;
-    int c_index = 0;
-    QString channelsUrl = "";
+    while(pos < list.length()) {
 
-    foreach(Channel* channel, list){
-        if (c_index++ > 0)
-            channelsUrl += ",";
-        channelsUrl += channel->getServiceName();
+        //Take sublist, max 50 items
+        QList<Channel*> sublist = list.mid(pos, 50);
 
-        if (++overall_index >= list.size() || c_index >= 50){
-            QString url = KRAKEN_API
-                    + QString("/streams?limit=%1&channel=").arg(c_index)
-                    + channelsUrl;
+        //Create comma-separated list of channels
+        QString channelsUrl = "";
+        foreach(Channel* channel, sublist){
+            if (!channelsUrl.isEmpty())
+                channelsUrl += ",";
 
-            netman->getStreams(url);
-
-            channelsUrl = "";
-            c_index = 0;
+            channelsUrl += channel->getServiceName();
         }
+
+        //Fetch channels
+        QString url = KRAKEN_API
+                + QString("/streams?")
+                + QString("limit=%1").arg(50) //Important!
+                + QString("&channel=") + channelsUrl;
+        netman->getStreams(url);
+
+        //Shift pos by 50
+        pos += sublist.length();
     }
 }
 

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -391,7 +391,7 @@ void ChannelManager::checkStreams(const QList<Channel *> &list)
     if (list.size() == 0)
         return;
 
-	int overall_index = 0;
+    int overall_index = 0;
     int c_index = 0;
     QString channelsUrl = "";
 

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -76,6 +76,7 @@ protected:
 
     QMap<int, QMap<int, QString>> lastEmoteSets;
     QMap<QString, QMap<QString, QMap<QString, QString>>> channelBadgeUrls;
+    QMap<QString, QMap<QString, QMap<QString, QMap<QString, QString>>>> channelBadgeBetaUrls;
 
 public:
     ChannelManager(NetworkManager *netman);
@@ -126,6 +127,7 @@ public:
 
     Q_INVOKABLE bool loadEmoteSets(bool reload, const QList<int> &emoteSetIDs);
     Q_INVOKABLE bool loadChannelBadgeUrls(const QString channel);
+    Q_INVOKABLE bool loadChannelBetaBadgeUrls(int channel);
 
     void setSwapChat(bool value);
     bool getSwapChat();
@@ -153,6 +155,7 @@ signals:
     void login(const QString &username, const QString &password);
     void emoteSetsLoaded(QVariantMap emoteSets);
     void channelBadgeUrlsLoaded(const QString &channel, QVariantMap badgeUrls);
+    void channelBadgeBetaUrlsLoaded(const QString &channel, QVariantMap badgeSetData);
 
 public slots:
     void checkFavourites();
@@ -176,6 +179,8 @@ private slots:
     void onUserNameUpdated(const QString &name);
     void onEmoteSetsUpdated(const QMap<int, QMap<int, QString>>);
     void innerChannelBadgeUrlsLoaded(const QString, const QMap<QString, QMap<QString, QString>> badgeUrls);
+    void innerChannelBadgeBetaUrlsLoaded(const int channelId, const QMap<QString, QMap<QString, QMap<QString, QString>>> badgeData);
+    void innerGlobalBadgeBetaUrlsLoaded(const QMap<QString, QMap<QString, QMap<QString, QString>>> badgeData);
     void addFollowedResults(const QList<Channel*>&, const quint32);
     void onNetworkAccessChanged(bool);
 };

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -75,6 +75,7 @@ protected:
     QList<int> lastRequestedEmoteSetIDs;
 
     QMap<int, QMap<int, QString>> lastEmoteSets;
+    QMap<QString, QMap<QString, QMap<QString, QString>>> channelBadgeUrls;
 
 public:
     ChannelManager(NetworkManager *netman);
@@ -124,6 +125,7 @@ public:
     Q_INVOKABLE void setMinimizeOnStartup(bool value);
 
     Q_INVOKABLE bool loadEmoteSets(bool reload, const QList<int> &emoteSetIDs);
+    Q_INVOKABLE bool loadChannelBadgeUrls(const QString channel);
 
     void setSwapChat(bool value);
     bool getSwapChat();
@@ -150,6 +152,7 @@ signals:
     void userNameUpdated(const QString name);
     void login(const QString &username, const QString &password);
     void emoteSetsLoaded(QVariantMap emoteSets);
+    void channelBadgeUrlsLoaded(const QString &channel, QVariantMap badgeUrls);
 
 public slots:
     void checkFavourites();
@@ -172,6 +175,7 @@ private slots:
     void addGames(const QList<Game*>&);
     void onUserNameUpdated(const QString &name);
     void onEmoteSetsUpdated(const QMap<int, QMap<int, QString>>);
+    void innerChannelBadgeUrlsLoaded(const QString, const QMap<QString, QMap<QString, QString>> badgeUrls);
     void addFollowedResults(const QList<Channel*>&, const quint32);
     void onNetworkAccessChanged(bool);
 };

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -329,7 +329,11 @@ void IrcChat::parseCommand(QString cmd) {
             }
             auto emoteEnd = i.value().first;
             auto emoteId = i.value().second;
-            messageList.append(emoteId);
+            QString emoteText = message.mid(emoteStart, emoteEnd - emoteStart + 1);
+            QVariantMap emoteObj;
+            emoteObj.insert("emoteId", emoteId);
+            emoteObj.insert("emoteText", emoteText);
+            messageList.append(emoteObj);
             cur = emoteEnd + 1;
         }
         if (cur < message.length()) {

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -185,7 +185,7 @@ void removeVariantListPairByFirstValue(QVariantList list, const QVariant value) 
     }
 }
 
-void IrcChat::addBadges(QVariantList &badges, QString channel) {
+bool IrcChat::addBadges(QVariantList &badges, QString channel) {
     qDebug() << "addBadges" << channel;
     auto channelEntry = badgesByChannel.find(channel);
     if (channelEntry != badgesByChannel.end()) {
@@ -195,6 +195,10 @@ void IrcChat::addBadges(QVariantList &badges, QString channel) {
             removeVariantListPairByFirstValue(badges, badge->first);
             badges.push_back(QVariantList({ badge->first, badge->second }));
         }
+        return true;
+    }
+    else {
+        return false;
     }
 }
 
@@ -213,9 +217,12 @@ void IrcChat::sendMessage(const QString &msg, const QVariantMap &relevantEmotes)
 		addWordSplit(displayMessage, ' ', message);
         message = substituteEmotesInMessage(message, relevantEmotes);
 
+        const QString channelName = "#" + room;
+
         QVariantList userBadges;
-        addBadges(userBadges, "GLOBAL");
-        addBadges(userBadges, "#" + room);
+        if (!addBadges(userBadges, channelName)) {
+            addBadges(userBadges, "GLOBAL");
+        }
 
         //TODO need the user's status info to show here
         disposeOfMessage(username, message, "", false, false, isAction, userBadges);

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -68,7 +68,16 @@ void IrcChat::RegisterEngineProviders(QQmlEngine & engine) {
 	engine.addImageProvider(IMAGE_PROVIDER_EMOTE, provider);
 }
 
-IrcChat::~IrcChat() { disconnect(); }
+IrcChat::~IrcChat() {
+    disconnect();
+    for (auto i = _emoteTable.begin(); i != _emoteTable.end(); i++ ) {
+        QImage * image = i.value();
+        i.value() = NULL;
+        if (image != NULL) {
+            delete image;
+        }
+    }
+}
 
 void IrcChat::join(const QString channel) {
 

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -139,6 +139,13 @@ bool IrcChat::connected() {
     return sock->state() == QTcpSocket::ConnectedState;
 }
 
+QVariantMap createEmoteEntry(int emoteId, QString emoteText) {
+    QVariantMap emoteObj;
+    emoteObj.insert("emoteId", emoteId);
+    emoteObj.insert("emoteText", emoteText);
+    return emoteObj;
+}
+
 void IrcChat::sendMessage(const QString &msg) {
     if (inRoom() && connected()) {
         sock->write(("PRIVMSG #" + room + " :" + msg + "\r\n").toStdString().c_str());
@@ -230,6 +237,16 @@ void IrcChat::addWordSplit(const QString & s, const QChar & sep, QVariantList & 
 	}
 }
 
+void IrcChat::disposeOfMessage(QString nickname, QVariantList messageList, QString color, bool subscriber, bool turbo, bool isAction) {
+    if (activeDownloadCount == 0) {
+        emit messageReceived(nickname, messageList, color, subscriber, turbo, isAction);
+    }
+    else {
+        // queue message to be shown when downloads are complete
+        msgQueue.push_back({ nickname, messageList, color, subscriber, turbo, isAction });
+    }
+}
+
 void IrcChat::parseCommand(QString cmd) {
     if(cmd.startsWith("PING ")) {
         sock->write("PONG\r\n");
@@ -288,16 +305,9 @@ void IrcChat::parseCommand(QString cmd) {
             auto key = emote.left(emote.indexOf(':'));
             auto positions = emote.remove(0, emote.indexOf(':')+1);
             //qDebug() << "key " << key;
-			if (!emotesCurrentlyDownloading.contains(key)) {
-				// if this emote isn't already downloading, it's safe to load the cache file or download if not in the cache
-                if (downloadEmotes(key)) {
-					emotesCurrentlyDownloading.insert(key);
-					activeDownloadCount += 1;
-				}
-			}
-			else {
-				qDebug() << "download of " << key << " already in progress";
-			}
+
+            makeEmoteAvailable(key);
+
 			for(auto emotePlc : positions.split(',')) {
               auto firstAndLast = emotePlc.split('-');
               int first = firstAndLast[0].toInt();
@@ -330,10 +340,7 @@ void IrcChat::parseCommand(QString cmd) {
             auto emoteEnd = i.value().first;
             auto emoteId = i.value().second;
             QString emoteText = message.mid(emoteStart, emoteEnd - emoteStart + 1);
-            QVariantMap emoteObj;
-            emoteObj.insert("emoteId", emoteId);
-            emoteObj.insert("emoteText", emoteText);
-            messageList.append(emoteObj);
+            messageList.append(createEmoteEntry(emoteId, emoteText));
             cur = emoteEnd + 1;
         }
         if (cur < message.length()) {
@@ -345,13 +352,7 @@ void IrcChat::parseCommand(QString cmd) {
             nickname = displayName;
         }
 
-        if(activeDownloadCount == 0) {
-          emit messageReceived(nickname, messageList, color, subscriber, turbo, isAction);
-        }
-        else {
-          // queue message to be shown when downloads are complete
-		  msgQueue.push_back({nickname, messageList, color, subscriber, turbo, isAction});
-        }
+        disposeOfMessage(nickname, messageList, color, subscriber, turbo, isAction);
         return;
     }
     if(cmd.contains("NOTICE")) {
@@ -435,19 +436,30 @@ bool IrcChat::downloadEmotes(QString key) {
     return true;
 }
 
+bool IrcChat::makeEmoteAvailable(QString key) {
+    /* Make emote available by downloading it or loading it from cache if not already loaded.
+     * Returns true if caller should wait for a downloadComplete event before using the emote */
+    if (emotesCurrentlyDownloading.contains(key)) {
+        // download of this emote in progress
+        return true;
+    }
+    else if (downloadEmotes(key)) {
+        // if this emote isn't already downloading, it's safe to load the cache file or download if not in the cache
+        emotesCurrentlyDownloading.insert(key);
+        activeDownloadCount += 1;
+        return true;
+    }
+    else {
+        // we already had the emote locally and don't need to wait for it to download
+        return false;
+    }
+}
+
 bool IrcChat::bulkDownloadEmotes(QList<QString> emoteIDs) {
     bool waitForDownloadComplete = false;
     for (auto key : emoteIDs) {
-        if (emotesCurrentlyDownloading.contains(key)) {
-            // download of this emote in progress
+        if (makeEmoteAvailable(key)) {
             waitForDownloadComplete = true;
-        } else if (downloadEmotes(key)) {
-            // if this emote isn't already downloading, it's safe to load the cache file or download if not in the cache
-            emotesCurrentlyDownloading.insert(key);
-            activeDownloadCount += 1;
-            waitForDownloadComplete = true;
-        } else {
-            // we already had the emote locally and don't need to wait for it to download
         }
     }
     return waitForDownloadComplete;

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -169,10 +169,12 @@ QVariantList IrcChat::substituteEmotesInMessage(const QVariantList & message, co
 }
 
 void IrcChat::addBadges(QVariantMap &badges, QString channel) {
+    qDebug() << "addBadges" << channel;
     auto channelEntry = badgesByChannel.find(channel);
     if (channelEntry != badgesByChannel.end()) {
         auto curBadges = channelEntry.value();
         for (auto badge = curBadges.constBegin(); badge != curBadges.constEnd(); badge++) {
+            qDebug() << "badge" << channel << badge.key() << badge.value();
             badges.remove(badge.key());
             badges.insert(badge.key(), badge.value());
         }
@@ -196,7 +198,7 @@ void IrcChat::sendMessage(const QString &msg, const QVariantMap &relevantEmotes)
 
         QVariantMap userBadges;
         addBadges(userBadges, "GLOBAL");
-        addBadges(userBadges, room);
+        addBadges(userBadges, "#" + room);
 
         //TODO need the user's status info to show here
         disposeOfMessage(username, message, "", false, false, isAction, userBadges);
@@ -449,6 +451,12 @@ void IrcChat::parseCommand(QString cmd) {
 			if (tag.key == "badges") {
                 badgesByChannel.remove("GLOBAL");
                 auto badges = parseBadges(tag.value);
+
+                qDebug() << "Updating user global badges from GLOBALUSERSTATE:";
+                for (auto entry = badges.constBegin(); entry != badges.constEnd(); entry++) {
+                    qDebug() << "  " << entry.key() << ":" << entry.value();
+                }
+
                 badgesByChannel.insert("GLOBAL", badges);
                 emit myBadgesForChannel("GLOBAL", badges);
 			}
@@ -473,6 +481,12 @@ void IrcChat::parseCommand(QString cmd) {
             if (tag.key == "badges") {
                 badgesByChannel.remove(channel);
                 auto badges = parseBadges(tag.value);
+
+                qDebug() << "Updating user badges for" << channel << "from USERSTATE:";
+                for (auto entry = badges.constBegin(); entry != badges.constEnd(); entry++) {
+                    qDebug() << "  " << entry.key() << ":" << entry.value();
+                }
+
                 badgesByChannel.insert(channel, badges);
                 emit myBadgesForChannel(channel, badges);
             }

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -25,6 +25,12 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QDir>
+#include <QStandardPaths>
+#include <QImage>
+
+const QString IMAGE_PROVIDER_EMOTE = "emote";
+const QString EMOTICONS_URL_FORMAT = "https://static-cdn.jtvnw.net/emoticons/v1/%1/1.0";
 
 IrcChat::IrcChat(QObject *parent) :
     QObject(parent) {
@@ -45,6 +51,21 @@ IrcChat::IrcChat(QObject *parent) :
     connect(sock, SIGNAL(disconnected()), this, SLOT(onSockStateChanged()));
 
     room = "";
+
+	emoteDir = QDir(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QString("/emotes"));
+	emoteDirPathImpl = "image://" + IMAGE_PROVIDER_EMOTE;
+
+	activeDownloadCount = 0;
+}
+
+void IrcChat::initProviders() {
+	auto engine = qmlEngine(this);
+	RegisterEngineProviders(*engine);
+}
+
+void IrcChat::RegisterEngineProviders(QQmlEngine & engine) {
+	auto provider = new CachedImageProvider(_emoteTable);
+	engine.addImageProvider(IMAGE_PROVIDER_EMOTE, provider);
 }
 
 IrcChat::~IrcChat() { disconnect(); }
@@ -63,8 +84,6 @@ void IrcChat::join(const QString channel) {
 
     // Join channel's chat room
     sock->write(("JOIN #" + channel + "\r\n").toStdString().c_str());
-
-
 
     qDebug() << "Joined channel " << channel;
 }
@@ -114,8 +133,18 @@ bool IrcChat::connected() {
 void IrcChat::sendMessage(const QString &msg) {
     if (inRoom() && connected()) {
         sock->write(("PRIVMSG #" + room + " :" + msg + "\r\n").toStdString().c_str());
+
+		bool isAction = false;
+		QVariantList message;
+		const QString ME_PREFIX = "/me ";
+		QString displayMessage = msg;
+		if (displayMessage.startsWith(ME_PREFIX)) {
+			isAction = true;
+			displayMessage = displayMessage.mid(ME_PREFIX.length());
+		}
+		addWordSplit(displayMessage.toHtmlEscaped(), ' ', message);
         //TODO need the user's status info to show here
-        emit messageReceived(username, msg.toHtmlEscaped(), "", false, false);
+        emit messageReceived(username, message, "", false, false, isAction);
     }
 }
 
@@ -179,18 +208,33 @@ void IrcChat::processError(QAbstractSocket::SocketError socketError) {
     errorOccured(err);
 }
 
+void IrcChat::addWordSplit(const QString & s, const QChar & sep, QVariantList & l) {
+	bool first = true;
+	for (auto part : s.split(sep)) {
+		if (first) {
+			first = false;
+			l.append(part);
+		}
+		else {
+			l.append(QString(sep) + part);
+		}
+	}
+}
+
 void IrcChat::parseCommand(QString cmd) {
     if(cmd.startsWith("PING ")) {
         sock->write("PONG\r\n");
         return;
     }
     if(cmd.contains("PRIVMSG")) {
+
         // Structure of message: '@color=#HEX;display-name=NicK;emotes=id:start-end,start-end/id:start-end;subscriber=0or1;turbo=0or1;user-type=type :nick!nick@nick.tmi.twitch.tv PRIVMSG #channel :message'
 
         QString displayName = "";
         QString color = "";
         bool subscriber = false;
         bool turbo = false;
+        QString emotes = "";
 
         if (cmd.at(0) == QChar('@')) {
             // tags are present
@@ -213,18 +257,88 @@ void IrcChat::parseCommand(QString cmd) {
                 else if (key == "turbo") {
                     turbo = (value == "1");
                 }
+				else if (key == "emotes") {
+					emotes = value;
+				}
             }
         }
 
         QString params = cmd.left(cmd.indexOf("PRIVMSG"));
         QString nickname = params.left(params.lastIndexOf('!')).remove(0, params.lastIndexOf(':') + 1);
+        QString message = cmd.remove(0, cmd.indexOf(':', cmd.indexOf("PRIVMSG")) + 1);
+        QString oldmessage = cmd.remove(0, cmd.indexOf(':', cmd.indexOf("PRIVMSG")) + 1);
+        //qDebug() << "emotes " << emotes;
+        //qDebug() << "oldmessage " << oldmessage;
 
+        QMap<int, QPair<int, int>> emotePositionsMap;
+
+        if(emotes != "") {
+          auto emoteList = emotes.split('/');
+
+          for(auto emote : emoteList) {
+            auto key = emote.left(emote.indexOf(':'));
+            auto positions = emote.remove(0, emote.indexOf(':')+1);
+            //qDebug() << "key " << key;
+			if (!emotesCurrentlyDownloading.contains(key)) {
+				// if this emote isn't already downloading, it's safe to load the cache file or download if not in the cache
+                if (downloadEmotes(key)) {
+					emotesCurrentlyDownloading.insert(key);
+					activeDownloadCount += 1;
+				}
+			}
+			else {
+				qDebug() << "download of " << key << " already in progress";
+			}
+			for(auto emotePlc : positions.split(',')) {
+              auto firstAndLast = emotePlc.split('-');
+              int first = firstAndLast[0].toInt();
+              int last = firstAndLast.length() > 1 ? firstAndLast[1].toInt() : first;
+
+              emotePositionsMap.insert(first, qMakePair(last, key.toInt()));
+            }
+          }
+        }
+
+		bool isAction = false;
+		
+		// parse IRC action before applying emotes, as emote indices are relative to the content of the action
+		const QString ACTION_PREFIX = QString(QChar(1)) + "ACTION ";
+		const QString ACTION_SUFFIX = QString(QChar(1));
+		if (message.startsWith(ACTION_PREFIX) && message.endsWith(ACTION_SUFFIX)) {
+			isAction = true;
+			message = message.mid(ACTION_PREFIX.length(), message.length() - ACTION_SUFFIX.length() - ACTION_PREFIX.length());
+		}
+
+		// cut up message into an ordered list of text fragments and emotes
+        QVariantList messageList;
+
+        int cur = 0;
+        for (auto i = emotePositionsMap.constBegin(); i != emotePositionsMap.constEnd(); i++) {
+            auto emoteStart = i.key();
+            if (emoteStart > cur) {
+				addWordSplit(message.mid(cur, emoteStart - cur).toHtmlEscaped(), ' ', messageList);
+            }
+            auto emoteEnd = i.value().first;
+            auto emoteId = i.value().second;
+            messageList.append(emoteId);
+            cur = emoteEnd + 1;
+        }
+        if (cur < message.length()) {
+			addWordSplit(message.mid(cur, message.length() - cur).toHtmlEscaped(), ' ', messageList);
+        }
+
+        //qDebug() << "messageList " << messageList;
         if (displayName.length() > 0) {
             nickname = displayName;
         }
 
-        QString message = cmd.remove(0, cmd.indexOf(':', cmd.indexOf("PRIVMSG")) + 1);
-        emit messageReceived(nickname, message.toHtmlEscaped(), color, subscriber, turbo);
+        if(activeDownloadCount == 0) {
+          emit messageReceived(nickname, messageList, color, subscriber, turbo, isAction);
+        }
+        else {
+          // queue message to be shown when downloads are complete
+		  msgQueue.push_back({nickname, messageList, color, subscriber, turbo, isAction});
+        }
         return;
     }
     if(cmd.contains("NOTICE")) {
@@ -242,4 +356,133 @@ QString IrcChat::getParamValue(QString params, QString param) {
     QString paramValue = params.remove(0, params.indexOf(param + "="));
     paramValue = paramValue.left(paramValue.indexOf(';')).remove(0, paramValue.indexOf('=') + 1);
     return paramValue;
+}
+
+bool IrcChat::downloadEmotes(QString key) {
+    if(_emoteTable.contains(key)) {
+      qDebug() << "already in the table";
+        return false;
+    }
+    
+    QUrl url = EMOTICONS_URL_FORMAT.arg(key);
+    emoteDir.mkpath(".");
+
+    QString filename = emoteDir.absoluteFilePath(key + ".png");
+
+    if(emoteDir.exists(key + ".png")) {
+        qDebug() << "local file already exists";
+		loadEmoteImageFile(key, filename);
+        return false;
+    }
+	qDebug() << "downloading";
+
+    QNetworkRequest request(url);
+	QNetworkReply* _reply = nullptr;
+    _reply = _manager.get(request);
+
+	DownloadHandler * dh = new DownloadHandler(filename);
+
+    connect(_reply, &QNetworkReply::readyRead,
+      dh, &DownloadHandler::dataAvailable);
+    connect(_reply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error),
+      dh, &DownloadHandler::error);
+    connect(_reply, &QNetworkReply::finished,
+      dh, &DownloadHandler::replyFinished);
+	connect(dh, &DownloadHandler::downloadComplete,
+		this, &IrcChat::individualDownloadComplete);
+
+    return true;
+}
+
+CachedImageProvider::CachedImageProvider(QHash<QString, QImage*> & imageTable) : QQuickImageProvider(QQuickImageProvider::Image), imageTable(imageTable) {
+
+}
+
+QImage CachedImageProvider::requestImage(const QString &id, QSize * size, const QSize & requestedSize) {
+	//qDebug() << "Requested id" << id << "from image provider";
+	QImage * entry = NULL;
+	auto result = imageTable.find(id);
+	if (result != imageTable.end()) {
+		entry = *result;
+	}
+	if (entry) {
+		if (size) {
+			*size = entry->size();
+		}
+		return *entry;
+	}
+	return QImage();
+}
+
+DownloadHandler::DownloadHandler(QString filename) : filename(filename), hadError(false) {
+    _file.setFileName(filename);
+    _file.open(QFile::WriteOnly);
+	qDebug() << "starting download of" << filename;
+}
+
+void DownloadHandler::dataAvailable() {
+  QNetworkReply* _reply = qobject_cast<QNetworkReply*>(sender());
+  auto buffer = _reply->readAll();
+  _file.write(buffer.data(), buffer.size());
+}
+
+void DownloadHandler::error(QNetworkReply::NetworkError code) {
+  hadError = true;
+  QNetworkReply* _reply = qobject_cast<QNetworkReply*>(sender());
+  qDebug() << "Network error downloading" << filename << ":" << _reply->errorString();
+}
+
+void DownloadHandler::replyFinished() {
+  QNetworkReply* _reply = qobject_cast<QNetworkReply*>(sender());
+  if(_reply) {
+    _reply->deleteLater();
+	_file.close();
+    //qDebug() << _file.fileName();
+    //might need something for windows for the forwardslash..
+    qDebug() << "download of" << _file.fileName() << "complete";
+
+    emit downloadComplete(_file.fileName(), hadError);
+  }
+}
+
+void IrcChat::loadEmoteImageFile(QString emoteKey, QString filename) {
+    QImage* emoteImg = new QImage();
+    emoteImg->load(filename);
+    _emoteTable.insert(emoteKey, emoteImg);
+}
+
+void IrcChat::individualDownloadComplete(QString filename, bool hadError) {
+    DownloadHandler * dh = qobject_cast<DownloadHandler*>(sender());
+    delete dh;
+    
+	QString emoteKey = filename.left(filename.indexOf(".png")).remove(0, filename.lastIndexOf('/') + 1);
+	if (hadError) {
+		// delete partial download if any
+		QFile(filename).remove();
+	} else {
+		loadEmoteImageFile(emoteKey, filename);
+	}
+    
+	if (activeDownloadCount > 0) {
+		activeDownloadCount--;
+		qDebug() << activeDownloadCount << "active downloads remaining";
+	}
+    
+	emotesCurrentlyDownloading.remove(emoteKey);
+
+	if (activeDownloadCount == 0) {
+		//qDebug() << "Download queue complete; posting pending messages";
+		while (!msgQueue.empty()) {
+			ChatMessage tmpMsg = msgQueue.first();
+			emit messageReceived(tmpMsg.name, tmpMsg.messageList, tmpMsg.color, tmpMsg.subscriber, tmpMsg.turbo, tmpMsg.isAction);
+			msgQueue.pop_front();
+		}
+	}
+
+	//msgQueue.pop_front();
+	emit downloadComplete();
+}
+
+QHash<QString, QImage*> IrcChat::emoteTable() {
+  return _emoteTable;
 }

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -171,7 +171,7 @@ private:
     void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantList badges);
     bool makeEmoteAvailable(QString key);
     QVariantList substituteEmotesInMessage(const QVariantList & message, const QVariantMap &relevantEmotes);
-    void addBadges(QVariantList & badges, const QString channel);
+    bool addBadges(QVariantList & badges, const QString channel);
 };
 
 #endif // IRCCHAT_H

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -49,6 +49,8 @@ struct ChatMessage {
     bool mod;
     bool isAction;
     QVariantList badges;
+    bool isChannelNotice;
+    QString systemMessage;
 };
 
 // Handles state for an individual download
@@ -132,7 +134,7 @@ signals:
     void connectedChanged();
     void emoteSetIDsChanged();
     void anonymousChanged();
-    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool mod, bool isAction, QVariantList badges);
+    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool mod, bool isAction, QVariantList badges, bool isChannelNotice, QString systemMessage);
     void noticeReceived(QString message);
     void myBadgesForChannel(QString channel, QList<QPair<QString, QString>> badges);
     void emoteTableChanged();
@@ -162,6 +164,8 @@ private:
     QList<ChatMessage> msgQueue;
 
     void parseCommand(QString cmd);
+    QMap<int, QPair<int, int>> parseEmotesTag(const QString emotes);
+    void createEmoteMessageList(const QMap<int, QPair<int, int>> & emotePositionsMap, QVariantList & messageList, const QString message);
     void addWordSplit(const QString & s, const QChar & sep, QVariantList & l);
     QString getParamValue(QString params, QString param);
     QTcpSocket *sock;
@@ -170,7 +174,7 @@ private:
     QMap<QString, QList<QPair<QString, QString>>> badgesByChannel;
     bool logged_in;
     int activeDownloadCount;
-    void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool mod, bool isAction, QVariantList badges);
+    void disposeOfMessage(ChatMessage m);
     bool makeEmoteAvailable(QString key);
     QVariantList substituteEmotesInMessage(const QVariantList & message, const QVariantMap &relevantEmotes);
     bool addBadges(QVariantList & badges, const QString channel);

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -47,6 +47,7 @@ struct ChatMessage {
     bool subscriber;
     bool turbo;
     bool isAction;
+    QVariantMap badges;
 };
 
 // Handles state for an individual download
@@ -129,8 +130,9 @@ signals:
     void connectedChanged();
     void emoteSetIDsChanged();
     void anonymousChanged();
-    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction);
+    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantMap badges);
     void noticeReceived(QString message);
+    void myBadgesForChannel(QString channel, QMap<QString, QString> badges);
     void emoteTableChanged();
 
     //emotes
@@ -162,12 +164,13 @@ private:
     QString getParamValue(QString params, QString param);
     QTcpSocket *sock;
     QString room;
-    QMap<QString, QString> badges;
+    QMap<QString, QMap<QString, QString>> badgesByChannel;
     bool logged_in;
     int activeDownloadCount;
-    void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction);
+    void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantMap badges);
     bool makeEmoteAvailable(QString key);
     QVariantList substituteEmotesInMessage(const QVariantList & message, const QVariantMap &relevantEmotes);
+    void addBadges(QVariantMap & badges, const QString channel);
 };
 
 #endif // IRCCHAT_H

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -157,7 +157,6 @@ private:
     QString getParamValue(QString params, QString param);
     QTcpSocket *sock;
     QString room;
-    QMap<QString, QString> badges;
     bool logged_in;
     int activeDownloadCount;
 };

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -138,7 +138,7 @@ signals:
     bool downloadError();
     
 public slots:
-    void sendMessage(const QString &msg);
+    void sendMessage(const QString &msg, const QVariantMap &relevantEmotes);
     void onSockStateChanged();
     void login();
     void individualDownloadComplete(QString filename, bool hadError);

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -47,7 +47,7 @@ struct ChatMessage {
     bool subscriber;
     bool turbo;
     bool isAction;
-    QVariantMap badges;
+    QVariantList badges;
 };
 
 // Handles state for an individual download
@@ -130,9 +130,9 @@ signals:
     void connectedChanged();
     void emoteSetIDsChanged();
     void anonymousChanged();
-    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantMap badges);
+    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantList badges);
     void noticeReceived(QString message);
-    void myBadgesForChannel(QString channel, QMap<QString, QString> badges);
+    void myBadgesForChannel(QString channel, QList<QPair<QString, QString>> badges);
     void emoteTableChanged();
 
     //emotes
@@ -164,13 +164,14 @@ private:
     QString getParamValue(QString params, QString param);
     QTcpSocket *sock;
     QString room;
-    QMap<QString, QMap<QString, QString>> badgesByChannel;
+    // map of channel name -> list of pairs (badge name, badge version)
+    QMap<QString, QList<QPair<QString, QString>>> badgesByChannel;
     bool logged_in;
     int activeDownloadCount;
-    void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantMap badges);
+    void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantList badges);
     bool makeEmoteAvailable(QString key);
     QVariantList substituteEmotesInMessage(const QVariantList & message, const QVariantMap &relevantEmotes);
-    void addBadges(QVariantMap & badges, const QString channel);
+    void addBadges(QVariantList & badges, const QString channel);
 };
 
 #endif // IRCCHAT_H

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -165,6 +165,9 @@ private:
     QMap<QString, QString> badges;
     bool logged_in;
     int activeDownloadCount;
+    void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction);
+    bool makeEmoteAvailable(QString key);
+    QVariantList substituteEmotesInMessage(const QVariantList & message, const QVariantMap &relevantEmotes);
 };
 
 #endif // IRCCHAT_H

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -46,6 +46,7 @@ struct ChatMessage {
     QString color;
     bool subscriber;
     bool turbo;
+    bool mod;
     bool isAction;
     QVariantList badges;
 };
@@ -107,7 +108,8 @@ public:
     void setAnonymous(bool newAnonymous);
     bool anonym;
     QStringList userSpecs;
-    QString userDisplayName;
+    QString userGlobalDisplayName;
+    QMap<QString, QString> userChannelDisplayName;
 
     //# Network
     bool connected();
@@ -130,7 +132,7 @@ signals:
     void connectedChanged();
     void emoteSetIDsChanged();
     void anonymousChanged();
-    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantList badges);
+    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool mod, bool isAction, QVariantList badges);
     void noticeReceived(QString message);
     void myBadgesForChannel(QString channel, QList<QPair<QString, QString>> badges);
     void emoteTableChanged();
@@ -168,10 +170,14 @@ private:
     QMap<QString, QList<QPair<QString, QString>>> badgesByChannel;
     bool logged_in;
     int activeDownloadCount;
-    void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool isAction, QVariantList badges);
+    void disposeOfMessage(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool mod, bool isAction, QVariantList badges);
     bool makeEmoteAvailable(QString key);
     QVariantList substituteEmotesInMessage(const QVariantList & message, const QVariantMap &relevantEmotes);
     bool addBadges(QVariantList & badges, const QString channel);
+    QString userGlobalColor;
+    QMap<QString, QString> userChannelColors;
+    QMap<QString, bool> userChannelMod;
+    QMap<QString, bool> userChannelSubscriber;
 };
 
 #endif // IRCCHAT_H

--- a/src/network/networkmanager.h
+++ b/src/network/networkmanager.h
@@ -71,6 +71,7 @@ public:
     void getUserFavourites(const QString &user_name, quint32 offset, quint32 limit);
     void editUserFavourite(const QString &access_token, const QString &user, const QString &channel, bool add);
     void getEmoteSets(const QString &access_token, const QList<int> &emoteSetIDs);
+    void getChannelBadgeUrls(const QString &access_token, const QString &channel);
 
     QNetworkAccessManager *getManager() const;
 
@@ -99,6 +100,7 @@ signals:
     void userNameOperationFinished(const QString&);
     void userEditFollowsOperationFinished();
     void getEmoteSetsOperationFinished(const QMap<int, QMap<int, QString>>);
+    void getChannelBadgeUrlsOperationFinished(const QString, const QMap<QString, QMap<QString, QString>>);
 
     void networkAccessChanged(bool up);
 
@@ -123,6 +125,7 @@ private slots:
     //Oauth slots
     void userReply();
     void emoteSetsReply();
+    void channelBadgeUrlsReply();
 
 private:
     QNetworkAccessManager *operation;

--- a/src/network/networkmanager.h
+++ b/src/network/networkmanager.h
@@ -72,6 +72,8 @@ public:
     void editUserFavourite(const QString &access_token, const QString &user, const QString &channel, bool add);
     void getEmoteSets(const QString &access_token, const QList<int> &emoteSetIDs);
     void getChannelBadgeUrls(const QString &access_token, const QString &channel);
+    void getChannelBadgeUrlsBeta(const int channelID);
+    void getGlobalBadgesUrlsBeta();
 
     QNetworkAccessManager *getManager() const;
 
@@ -101,6 +103,8 @@ signals:
     void userEditFollowsOperationFinished();
     void getEmoteSetsOperationFinished(const QMap<int, QMap<int, QString>>);
     void getChannelBadgeUrlsOperationFinished(const QString, const QMap<QString, QMap<QString, QString>>);
+    void getChannelBadgeBetaUrlsOperationFinished(const int, const QMap<QString, QMap<QString, QMap<QString, QString>>>);
+    void getGlobalBadgeBetaUrlsOperationFinished(const QMap<QString, QMap<QString, QMap<QString, QString>>>);
 
     void networkAccessChanged(bool up);
 
@@ -126,6 +130,8 @@ private slots:
     void userReply();
     void emoteSetsReply();
     void channelBadgeUrlsReply();
+    void channelBadgeUrlsBetaReply();
+    void globalBadgeUrlsBetaReply();
 
 private:
     QNetworkAccessManager *operation;

--- a/src/qml/IconButton.qml
+++ b/src/qml/IconButton.qml
@@ -20,6 +20,7 @@ Icon {
     id: root
     property bool checked: false
     property bool checkable: false
+    property alias mouseArea: mArea
 
     signal clicked()
 
@@ -28,12 +29,12 @@ Icon {
     }
     
     MouseArea {
+        id: mArea
         anchors.fill: parent
         hoverEnabled: true
         
         onHoveredChanged: {
-            if (!root.checked)
-                root.iconColor = containsMouse ? Styles.white : Styles.iconColor
+            root.iconColor = containsMouse ? Styles.white : (root.checked ? Styles.purple : Styles.iconColor)
         }
 
         onClicked: {

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -13,6 +13,7 @@
  */
 
 import QtQuick 2.5
+import QtQuick.Controls 2.1
 import "components"
 import "irc"
 import "styles.js" as Styles
@@ -400,6 +401,12 @@ Item {
 
                     anchors.centerIn: parent
                 }
+
+                ToolTip {
+                    visible: miniModeCheckBox.mouseArea.containsMouse
+                    delay: 666
+                    text: "Toggle floating player"
+                }
             }
 
             Item {
@@ -427,6 +434,7 @@ Item {
                 }
 
                 MouseArea {
+                    id: favArea
                     anchors.fill: parent
                     hoverEnabled: true
                     onHoveredChanged: {
@@ -451,6 +459,12 @@ Item {
                             }
                         }
                     }
+
+                    ToolTip {
+                        visible: parent.containsMouse
+                        delay: 666
+                        text: "Toggle followed"
+                    }
                 }
             }
 
@@ -467,6 +481,7 @@ Item {
                 height: width
 
                 MouseArea {
+                    id: chatButtonArea
                     anchors.fill: parent
                     onClicked: {
                         chatview.status++
@@ -475,6 +490,12 @@ Item {
 
                     onHoveredChanged: {
                         parent.iconColor = containsMouse ? Styles.textColor : Styles.iconColor
+                    }
+
+                    ToolTip {
+                        visible: parent.containsMouse
+                        delay: 666
+                        text: "Toggle chat"
                     }
                 }
             }
@@ -527,6 +548,12 @@ Item {
                     onHoveredChanged: {
                         togglePause.iconColor = containsMouse ? Styles.textColor : Styles.iconColor
                     }
+
+                    ToolTip {
+                        visible: parent.containsMouse
+                        delay: 666
+                        text: "Toggle playback"
+                    }
                 }
             }
 
@@ -547,6 +574,12 @@ Item {
 
                     onHoveredChanged: {
                         reloadButton.iconColor = containsMouse ? Styles.textColor : Styles.iconColor
+                    }
+
+                    ToolTip {
+                        visible: parent.containsMouse
+                        delay: 666
+                        text: "Reload stream"
                     }
                 }
             }
@@ -579,6 +612,7 @@ Item {
                 visible: !g_fullscreen
 
                 MouseArea {
+                    id: fitButtonArea
                     anchors.fill: parent
                     onClicked: {
                         if (!g_fullscreen) {
@@ -589,6 +623,12 @@ Item {
 
                     onHoveredChanged: {
                         parent.iconColor = containsMouse ? Styles.textColor : Styles.iconColor
+                    }
+
+                    ToolTip {
+                        visible: parent.containsMouse
+                        delay: 666
+                        text: "Fit to 16:9 aspect ratio"
                     }
                 }
             }
@@ -629,6 +669,7 @@ Item {
                 height: width
 
                 MouseArea {
+                    id: fsButtonArea
                     anchors.fill: parent
                     onClicked: g_fullscreen = !g_fullscreen
                     hoverEnabled: true
@@ -636,7 +677,13 @@ Item {
                     onHoveredChanged: {
                         parent.iconColor = containsMouse ? Styles.textColor : Styles.iconColor
                     }
-                }
+
+                    ToolTip {
+                        visible: parent.containsMouse
+                        delay: 666
+                        text: "Toggle fullscreen"
+                    }
+                }   
             }
 
             ComboBox {
@@ -752,6 +799,18 @@ Item {
         if (seekBar.containsMouse)
             return false
         if (reloadArea.containsMouse)
+            return false
+        if (chatButtonArea.containsMouse)
+            return false
+        if (fsButtonArea.containsMouse)
+            return false
+        if (miniModeCheckBox.mouseArea.containsMouse)
+            return false
+        if (fitButtonArea.containsMouse)
+            return false
+        if (favArea.containsMouse)
+            return false
+        if (sourcesBox.mouseArea.containsMouse)
             return false
 
         return true

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -45,11 +45,6 @@ Item {
     width: smallMode ? parent.width / 3 : parent.width
     height: smallMode ? width * 0.5625 : parent.height
 
-    onSmallModeChanged: {
-        if (smallMode)
-            chatview.status = 0
-    }
-
     //Renderer interface
     property alias renderer: loader.item
 
@@ -733,7 +728,7 @@ Item {
             right: !g_cman.swapChat ? parent.right : undefined
         }
 
-        width: visible ? dp(250) : 0
+        width: visible && !smallMode ? dp(250) : 0
 
         Behavior on width {
             NumberAnimation {

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -794,6 +794,7 @@ Item {
         }
 
         width: visible && !smallMode ? dp(250) : 0
+        chatWidth: dp(250)
 
         Behavior on width {
             NumberAnimation {

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -30,6 +30,8 @@ Item {
     property bool isVod: false
     property bool streamOnline: true
 
+    property bool cursorHidden: false
+
     //Minimode, bit ugly
     property bool smallMode: false
     property alias enableSmallMode: miniModeCheckBox.checked
@@ -328,6 +330,9 @@ Item {
             anchors.fill: parent
             hoverEnabled: true
             propagateComposedEvents: false
+
+            //Hide cursor when headers hide
+            cursorShape: cursorHidden ? Qt.BlankCursor : Qt.ArrowCursor
 
             onClicked: {
                 if (sourcesBox.open){
@@ -728,10 +733,17 @@ Item {
                 if (canHideHeaders()) {
                     header.hide()
                     footer.hide()
+
+                    cursorHidden = true
                 }
 
                 else
                     restart()
+            }
+            onRunningChanged: {
+                if (running) {
+                    cursorHidden = false
+                }
             }
         }
 

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -31,6 +31,7 @@ Item {
     property bool streamOnline: true
 
     property bool cursorHidden: false
+    property string currentQualityName
 
     //Minimode, bit ugly
     property bool smallMode: false
@@ -142,6 +143,8 @@ Item {
         console.debug("Loading: ", url)
 
         renderer.load(url, start)
+
+        currentQualityName = streamName
     }
 
     function getStreams(channel, vod){
@@ -205,16 +208,19 @@ Item {
         console.log("DEBUG STREAMS")
         var sourceNames = []
         for (var k in streams) {
-            console.log(k + " => " + streams[k])
+            //console.log(k + " => " + streams[k])
             sourceNames.push(k)
         }
 
         streamMap = streams
 
-        //TODO: sort sourceNames => [source , ... , mobile/smallest reso]
         sourcesBox.entries = sourceNames
 
-        sourcesBox.selectFirst()
+        if (currentQualityName && streamMap[currentQualityName])
+            loadAndPlay(currentQualityName)
+
+        else
+            sourcesBox.selectFirst()
     }
 
     function seekTo(position) {

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -187,7 +187,7 @@ Item {
         _favIcon.update()
         _label.visible = false
         setWatchingTitle()
-        chatview.joinChannel(currentChannel.name)
+        chatview.joinChannel(currentChannel.name, currentChannel._id)
         pollTimer.restart()
 
         requestSelectionChange(5)

--- a/src/qml/components/ComboBox.qml
+++ b/src/qml/components/ComboBox.qml
@@ -20,6 +20,7 @@ import "../styles.js" as Styles
 Rectangle {
     property var entries: []
     property alias open: list.visible
+    property alias mouseArea: mArea
 
     id: root
 
@@ -118,6 +119,7 @@ Rectangle {
 
 
     MouseArea {
+        id: mArea
         anchors.fill: parent
         hoverEnabled: true
 

--- a/src/qml/components/GridPicker.qml
+++ b/src/qml/components/GridPicker.qml
@@ -52,6 +52,7 @@ Rectangle {
         anchors.fill: parent
         iconSize: 60
         visible: root.loading
+        opacity: 0.5
         z: 2
     }
 

--- a/src/qml/components/GridPicker.qml
+++ b/src/qml/components/GridPicker.qml
@@ -20,7 +20,6 @@ import "../styles.js" as Styles
 Rectangle {
     id: root
 
-    property string text: "Picker"
     property bool loading: false
     property string filterTextProperty
 
@@ -54,20 +53,6 @@ Rectangle {
         iconSize: 60
         visible: root.loading
         z: 2
-    }
-
-    Text {
-        id: text
-        color: Styles.textColor
-        text: root.text
-        font.pixelSize: Styles.titleFont.smaller
-        anchors{
-            bottom: parent.bottom
-            left: parent.left
-            right: parent.right
-        }
-        wrapMode: Text.WordWrap
-        //renderType: Text.NativeRendering
     }
 
     function updateFilter() {

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -27,9 +27,11 @@ Item {
     signal emoteSetIDsChanged(var emoteSetIDs)
     signal downloadComplete()
     signal channelBadgeUrlsLoaded(string channel, var badgeUrls)
+    signal channelBadgeBetaUrlsLoaded(string channel, var badgeSetData)
 
     property alias isAnonymous: chat.anonymous
     property var channel: undefined
+    property var channelId: undefined
     property var singleShot: undefined
 
     Component.onCompleted: {
@@ -51,13 +53,20 @@ Item {
             console.log("onChannelBadgeUrlsLoaded", "channel", channel, "badgeUrls", badgeUrls);
             root.channelBadgeUrlsLoaded(channel, badgeUrls);
         }
+
+        onChannelBadgeBetaUrlsLoaded: {
+            console.log("onChannelBadgeBetaUrlsLoaded", "channel", channel, "badgeSetData", badgeSetData);
+            root.channelBadgeBetaUrlsLoaded(channel, badgeSetData);
+        }
     }
 
-    function joinChannel(channelName) {
+    function joinChannel(channelName, channelId) {
         chat.join(channelName)
         root.channel = channelName
+        root.channelId = channelId
         messageReceived("Joined channel #" + channelName, null, "", false, false, false, {})
         g_cman.loadChannelBadgeUrls(channelName);
+        g_cman.loadChannelBetaBadgeUrls(channelId);
     }
 
     function leaveChannel() {
@@ -75,7 +84,7 @@ Item {
     function reconnect() {
         leaveChannel()
         if (root.channel)
-            joinChannel(root.channel)
+            joinChannel(root.channel, root.channelId)
     }
 
     IrcChat {
@@ -85,7 +94,7 @@ Item {
             if (connected) {
                 console.log("Connected to chat")
                 if (root.channel) {
-                    joinChannel(root.channel)
+                    joinChannel(root.channel, root.channelId)
                 }
             } else {
                 console.log("Disconnected from chat")

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -20,12 +20,13 @@ import aldrog.twitchtube.ircchat 1.0
 Item {
     id: root
 
-    signal messageReceived(string user, variant message, string chatColor, bool subscriber, bool turbo, bool isAction)
+    signal messageReceived(string user, variant message, string chatColor, bool subscriber, bool turbo, bool isAction, var badges)
     signal setEmotePath(string value)
     signal notify(string message)
     signal clear()
     signal emoteSetIDsChanged(var emoteSetIDs)
     signal downloadComplete()
+    signal channelBadgeUrlsLoaded(string channel, var badgeUrls)
 
     property alias isAnonymous: chat.anonymous
     property var channel: undefined
@@ -45,12 +46,18 @@ Item {
 
             chat.reopenSocket()
         }
+
+        onChannelBadgeUrlsLoaded: {
+            console.log("onChannelBadgeUrlsLoaded", "channel", channel, "badgeUrls", badgeUrls);
+            root.channelBadgeUrlsLoaded(channel, badgeUrls);
+        }
     }
 
     function joinChannel(channelName) {
         chat.join(channelName)
         root.channel = channelName
-        messageReceived("Joined channel #" + channelName, null, "", false, false, false)
+        messageReceived("Joined channel #" + channelName, null, "", false, false, false, {})
+        g_cman.loadChannelBadgeUrls(channelName);
     }
 
     function leaveChannel() {
@@ -87,11 +94,12 @@ Item {
 
         onMessageReceived: {
             root.setEmotePath(emoteDirPath)
-            root.messageReceived(user, message, chatColor, subscriber, turbo, isAction)
+            root.messageReceived(user, message, chatColor, subscriber, turbo, isAction, badges)
         }
 
         onNoticeReceived: {
-            root.messageReceived("--NOTIFICATION--", message, null, null, false, false)
+            console.log("Notification received", message);
+            root.messageReceived("--NOTIFICATION--", [message], null, null, false, false, {})
         }
 
         onEmoteSetIDsChanged: {

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -64,7 +64,7 @@ Item {
         chat.join(channelName)
         root.channel = channelName
         root.channelId = channelId
-        messageReceived("Joined channel #" + channelName, null, "", false, false, false, {}, true, "")
+        messageReceived("notice", null, "", false, false, false, [], true, "Joined channel #" + channelName)
         g_cman.loadChannelBadgeUrls(channelName);
         g_cman.loadChannelBetaBadgeUrls(channelId);
     }

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -20,13 +20,18 @@ import aldrog.twitchtube.ircchat 1.0
 Item {
     id: root
 
-    signal messageReceived(string user, string message, string chatColor, bool subscriber, bool turbo)
+    signal messageReceived(string user, variant message, string chatColor, bool subscriber, bool turbo, bool isAction)
+    signal setEmotePath(string value)
     signal notify(string message)
     signal clear()
 
     property alias isAnonymous: chat.anonymous
     property var channel: undefined
     property var singleShot: undefined
+
+    Component.onCompleted: {
+        chat.initProviders()
+    }
 
     Connections {
         target: g_cman
@@ -43,7 +48,7 @@ Item {
     function joinChannel(channelName) {
         chat.join(channelName)
         root.channel = channelName
-        messageReceived("Joined channel #" + channelName, null, "", false, false)
+        messageReceived("Joined channel #" + channelName, null, "", false, false, false)
     }
 
     function leaveChannel() {
@@ -75,7 +80,8 @@ Item {
         }
 
         onMessageReceived: {
-            root.messageReceived(user, message, chatColor, subscriber, turbo)
+            root.setEmotePath(emoteDirPath)
+            root.messageReceived(user, message, chatColor, subscriber, turbo, isAction)
         }
 
         onNoticeReceived: {

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -43,7 +43,7 @@ Item {
     function joinChannel(channelName) {
         chat.join(channelName)
         root.channel = channelName
-        messageReceived("Joined channel #" + channelName, null)
+        messageReceived("Joined channel #" + channelName, null, "", false, false)
     }
 
     function leaveChannel() {
@@ -79,7 +79,7 @@ Item {
         }
 
         onNoticeReceived: {
-            root.messageReceived("--NOTIFICATION--", message)
+            root.messageReceived("--NOTIFICATION--", message, null, null, false, false)
         }
     }
 }

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -57,8 +57,8 @@ Item {
         chat.leave()
     }
 
-    function sendChatMessage(message) {
-        chat.sendMessage(message)
+    function sendChatMessage(message, relevantEmotes) {
+        chat.sendMessage(message, relevantEmotes)
     }
 
     function bulkDownloadEmotes(emotes) {

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -108,7 +108,7 @@ Item {
 
         onNoticeReceived: {
             console.log("Notification received", message);
-            root.messageReceived("--NOTIFICATION--", [message], null, null, false, false, {}, true, "")
+            root.messageReceived("channel", [], null, null, false, false, {}, true, message)
         }
 
         onEmoteSetIDsChanged: {

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -20,7 +20,7 @@ import aldrog.twitchtube.ircchat 1.0
 Item {
     id: root
 
-    signal messageReceived(string user, variant message, string chatColor, bool subscriber, bool turbo, bool isAction, var badges)
+    signal messageReceived(string user, variant message, string chatColor, bool subscriber, bool turbo, bool isAction, var badges, bool isChannelNotice, string systemMessage)
     signal setEmotePath(string value)
     signal notify(string message)
     signal clear()
@@ -64,7 +64,7 @@ Item {
         chat.join(channelName)
         root.channel = channelName
         root.channelId = channelId
-        messageReceived("Joined channel #" + channelName, null, "", false, false, false, {})
+        messageReceived("Joined channel #" + channelName, null, "", false, false, false, {}, true, "")
         g_cman.loadChannelBadgeUrls(channelName);
         g_cman.loadChannelBetaBadgeUrls(channelId);
     }
@@ -103,12 +103,12 @@ Item {
 
         onMessageReceived: {
             root.setEmotePath(emoteDirPath)
-            root.messageReceived(user, message, chatColor, subscriber, turbo, isAction, badges)
+            root.messageReceived(user, message, chatColor, subscriber, turbo, isAction, badges, isChannelNotice, systemMessage)
         }
 
         onNoticeReceived: {
             console.log("Notification received", message);
-            root.messageReceived("--NOTIFICATION--", [message], null, null, false, false, {})
+            root.messageReceived("--NOTIFICATION--", [message], null, null, false, false, {}, true, "")
         }
 
         onEmoteSetIDsChanged: {

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -30,6 +30,7 @@ Item {
     property int fontSize: Styles.titleFont.smaller
     property var pmsg: JSON.parse(msg)
     property var badgeEntries: JSON.parse(jsonBadgeEntries)
+    property var highlightOpacity: 1.0
 
     property string systemMessageBackgroundColor: "#333333"
 
@@ -131,6 +132,7 @@ Item {
 
         visible: isChannelNotice
         color: root.systemMessageBackgroundColor
+        opacity: root.highlightOpacity
     }
 
     Text {

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -180,7 +180,7 @@ Item {
       Text {
         id: userName
         // if this ChatMessage is a channel notice with no user message text, don't show a user chat line
-        visible: !root.isChannelNotice || !root.systemMessage || pmsg.length > 0
+        visible: !root.isChannelNotice || !root.systemMessage || (pmsg && pmsg.length > 0)
         verticalAlignment: Text.AlignVCenter
         color: Styles.textColor
         font.pixelSize: fontSize

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -14,6 +14,7 @@
 
 import QtQuick 2.0
 import QtQuick.Layouts 1.0
+import QtQuick.Controls 2.0
 import "../styles.js" as Styles
 
 Item {
@@ -66,9 +67,12 @@ Item {
         for (var j=0; j < msg.length; j++) {
             var mlist = msg[j];
             console.log("cur mlist entry " + j.toString() + " typeof is " + typeof(mlist));
-            if (typeof(mlist) == "number") {
+            if (typeof(mlist) == "object") {
                 // it's an emote
-                var imgUrl = emoteDirPath + "/" + mlist.toString();
+                var emoteId = mlist.emoteId;
+                var emoteText = mlist.emoteText;
+
+                var imgUrl = emoteDirPath + "/" + emoteId.toString();
 
                 _text.text += "<img src=\"" + imgUrl + "\"></img>";
 
@@ -170,11 +174,23 @@ Item {
       }
     }
     property Component imgThing: Component {
-      Image {
-        Component.onCompleted: {
-          source = "image://emote/" + msgItem.toString();
-        }
-        asynchronous: true
+      MouseArea {
+          id: _emoteImgMouseArea
+          hoverEnabled: true
+          width: _emoteImg.width
+          height: _emoteImg.height
+          Image {
+            id: _emoteImg
+            asynchronous: true
+            Component.onCompleted: {
+              source = "image://emote/" + msgItem.emoteId.toString();
+            }
+
+            ToolTip {
+                visible: _emoteImgMouseArea.containsMouse && msgItem.emoteText != null
+                text: msgItem.emoteText
+            }
+          }
       }
     }
 

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -100,13 +100,13 @@ Item {
         var pseudoUrlPattern = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
         var out = pref + str.replace(urlPattern, '<a href="$&">$&</a>').replace(pseudoUrlPattern, '$1<a href="http://$2">$2</a>');
 
-        console.log("makeUrl", str, out);
+        //console.log("makeUrl", str, out);
         return out;
     }
 
     function isUrl(str) {
         var result = str.match(/^ ?(https?:\/\/)?([\da-z\.-]+)\.([a-z]{2,6})([\/\w \.-]*)*\/?$/);
-        console.log("isUrl", str, result);
+        //console.log("isUrl", str, result);
         return result
     }
 
@@ -196,10 +196,10 @@ Item {
 
     function externalLinkActivation(link)
     {
-        console.log("externalLinkActivation", link, "passed");
+        //console.log("externalLinkActivation", link, "passed");
         if (link.substr(0,5) !== "user:")
         {
-            console.log("opening link")
+            //console.log("opening link")
             Qt.openUrlExternally(link)
         }
     }

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -25,9 +25,13 @@ Item {
     property bool isAction
     property string jsonBadgeEntries
     property string emoteDirPath
+    property bool isChannelNotice
+    property string systemMessage
     property int fontSize: Styles.titleFont.smaller
     property var pmsg: JSON.parse(msg)
     property var badgeEntries: JSON.parse(jsonBadgeEntries)
+
+    property string systemMessageBackgroundColor: "#333333"
 
     height: childrenRect.height
 
@@ -117,12 +121,54 @@ Item {
         return result
     }
 
+    Rectangle {
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: _systemMessageLine.top
+            bottom: _messageLineFlow.bottom
+        }
+
+        visible: isChannelNotice
+        color: root.systemMessageBackgroundColor
+    }
+
+    Text {
+        id: _systemMessageLine
+        anchors {
+            left: parent.left
+            right: parent.right
+        }
+
+        visible: root.isChannelNotice && root.systemMessage != ""
+        color: Styles.textColor
+        text: root.systemMessage
+        font.pixelSize: fontSize
+        wrapMode: Text.WordWrap
+
+        Component.onCompleted: {
+            if (!_systemMessageLine.visible) {
+                _systemMessageLine.height = 0;
+            }
+        }
+    }
+
     CustomFlow {
       id: _messageLineFlow
       ySpacing: 1
       anchors {
+          top: _systemMessageLine.bottom
           left: parent.left
           right: parent.right
+      }
+
+      Component.onCompleted: {
+          // if this ChatMessage is a channel notice with no user message text, don't show a user chat line
+          if (root.isChannelNotice && root.systemMessage && pmsg.length == 0) {
+              userName.visible = false;
+              userName.height = 0;
+              badgeEntries = [];
+          }
       }
 
       vAlign: vAlignCenter

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -41,71 +41,6 @@ Item {
 
     height: childrenRect.height
 
-    /*
-    Component.onCompleted: {
-        //console.log("Got: " + msg);
-        //console.log("Got toString: " + msg.toString());
-        var rmsg = JSON.parse(msg);
-
-        if (rmsg)
-        {
-            _text.text = "<font color=\""+chat.colors[user]+"\"><a href=\"user:%1\"><b>%1</b></a>".arg(user);
-            if (isAction) {
-                _text.text += " ";
-                parseMsg(rmsg);
-            }
-            _text.text += "</font>";
-            if (!isAction) {
-                _text.text += ": ";
-                parseMsg(rmsg)
-            }
-        }
-        else
-        {
-            _text.text = "<font color=\"#FFFFFF\"><b>%1</b></font>".arg(user)
-        }
-        _text.user = user
-    }
-    */
-
-    function parseMsg(msg) {
-        console.log("We are in parseMsg()");
-        console.log("msg typeof is " + typeof(msg));
-        //console.log("msg length is " + msg.length.toString());
-        console.log("msg tostring is " + msg.toString());
-
-        console.log("typeof msg.length " + typeof(msg.length));
-        console.log("msg.length " + msg.length.toString());
-
-        for (var j=0; j < msg.length; j++) {
-            var mlist = msg[j];
-            console.log("cur mlist entry " + j.toString() + " typeof is " + typeof(mlist));
-            if (typeof(mlist) == "object") {
-                // it's an emote
-                var emoteId = mlist.emoteId;
-                var emoteText = mlist.emoteText;
-
-                var imgUrl = emoteDirPath + "/" + emoteId.toString();
-
-                _text.text += "<img src=\"" + imgUrl + "\"></img>";
-
-            } else {
-                mlist = mlist.split(" ")
-                var textParts = [];
-
-                for (var i=0; i < mlist.length; i++) {
-                    var str = mlist[i]
-
-                    textParts.push(!isUrl(str) ? str : makeUrl(str))
-                }
-                _text.text += textParts.join(" ");
-            }
-
-        }
-
-        console.log("Created text object: " + _text.text);
-    }
-
     function makeUrl(str) {
         var pref = "";
         if (str.length && (str.charAt(0) === " ")) {
@@ -330,40 +265,4 @@ Item {
             Qt.openUrlExternally(link)
         }
     }
-
-    /*
-    Text {
-        id: _text
-        property string user: ""
-        anchors {
-            left: parent.left
-            right: parent.right
-        }
-        verticalAlignment: Text.AlignVCenter
-        color: Styles.textColor
-        font.pixelSize: fontSize
-        linkColor: Styles.purple
-        wrapMode: Text.WordWrap
-        onLinkActivated: function(link)
-        {
-            if (link.substr(0,5) === "user:")
-            {
-                var value = "@"+link.replace('user:',"")+', '
-                if (_input.text === "")
-                {
-                    _input.text = value
-                }
-                else {
-                    _input.text = _input.text + ' '+ value
-                }
-
-            }
-            else
-            {
-                Qt.openUrlExternally(link)
-            }
-        }
-
-    }
-    */
 }

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -162,15 +162,6 @@ Item {
           right: parent.right
       }
 
-      Component.onCompleted: {
-          // if this ChatMessage is a channel notice with no user message text, don't show a user chat line
-          if (root.isChannelNotice && root.systemMessage && pmsg.length == 0) {
-              userName.visible = false;
-              userName.height = 0;
-              badgeEntries = [];
-          }
-      }
-
       vAlign: vAlignCenter
 
       Repeater {
@@ -186,11 +177,21 @@ Item {
 
       Text {
         id: userName
+        // if this ChatMessage is a channel notice with no user message text, don't show a user chat line
+        visible: !root.isChannelNotice || !root.systemMessage || pmsg.length > 0
         verticalAlignment: Text.AlignVCenter
         color: Styles.textColor
         font.pixelSize: fontSize
         text: "<font color=\""+chat.colors[user]+"\"><a href=\"user:%1\"><b>%1</b></a></font>".arg(user) + (isAction? "&nbsp;": ":&nbsp;")
         onLinkActivated: userLinkActivation(link)
+
+        Component.onCompleted: {
+            console.log("username complete", isChannelNotice, systemMessage, pmsg, pmsg.length)
+            if (!userName.visible) {
+                userName.height = 0;
+                badgeEntries = [];
+            }
+        }
 
         MouseArea {
             anchors.fill: parent

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -145,6 +145,12 @@ Item {
         font.pixelSize: fontSize
         text: "<font color=\""+chat.colors[user]+"\"><a href=\"user:%1\"><b>%1</b></a></font>".arg(user) + (isAction? "&nbsp;": ":&nbsp;")
         onLinkActivated: userLinkActivation(link)
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+            acceptedButtons: Qt.NoButton
+        }
       }
 
       Repeater {
@@ -186,6 +192,12 @@ Item {
         textFormat: Text.RichText
         wrapMode: Text.WordWrap
         onLinkActivated: externalLinkActivation(link)
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+            acceptedButtons: Qt.NoButton
+        }
       }
     }
     property Component imgThing: Component {
@@ -233,6 +245,10 @@ Item {
                 text: badgeEntry.name
             }
           }
+
+          property bool clickable: badgeEntry.click_action == "visit_url"
+
+          cursorShape: clickable ? Qt.PointingHandCursor : Qt.ArrowCursor
 
           onClicked: {
               console.log("badge clicked, action", badgeEntry.click_action);

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -32,7 +32,7 @@ Item {
     property var badgeEntries: JSON.parse(jsonBadgeEntries)
     property var highlightOpacity: 1.0
 
-    property string systemMessageBackgroundColor: "#333333"
+    property string channelNoticeBackgroundColor: "#444444"
 
     property bool showUsernameLine: !isChannelNotice || !systemMessage || (pmsg && pmsg.length > 0)
     property bool showSystemMessageLine: isChannelNotice && systemMessage != ""
@@ -136,7 +136,7 @@ Item {
         }
 
         visible: isChannelNotice
-        color: root.systemMessageBackgroundColor
+        color: root.channelNoticeBackgroundColor
         opacity: root.highlightOpacity
     }
 

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -30,7 +30,7 @@ Item {
     property int fontSize: Styles.titleFont.smaller
     property var pmsg: JSON.parse(msg)
     property var badgeEntries: JSON.parse(jsonBadgeEntries)
-    property var visibleBadgeEntries: visible? badgeEntries : []
+    property var visibleBadgeEntries: userName.visible? badgeEntries : []
     property var highlightOpacity: 1.0
 
     property string systemMessageBackgroundColor: "#333333"

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -233,6 +233,15 @@ Item {
                 text: badgeEntry.name
             }
           }
+
+          onClicked: {
+              console.log("badge clicked, action", badgeEntry.click_action);
+              if (badgeEntry.click_action == "visit_url") {
+                  var link = badgeEntry.click_url;
+                  console.log("Launching url", link);
+                  Qt.openUrlExternally(link);
+              }
+          }
       }
     }
 

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -90,13 +90,24 @@ Item {
     }
 
     function makeUrl(str) {
-        var urlPattern = /\b(?:https?):\/\/[a-z0-9-+&@#\/%?=~_|!:,.;]*[a-z0-9-+&@#\/%=~_|]/gim;
+        var pref = "";
+        if (str.length && (str.charAt(0) === " ")) {
+            pref = "&nbsp;";
+            str = str.substring(1);
+        }
+
+        var urlPattern = / ?\b(?:https?):\/\/[a-z0-9-+&@#\/%?=~_|!:,.;]*[a-z0-9-+&@#\/%=~_|]/gim;
         var pseudoUrlPattern = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
-        return str.replace(urlPattern, '<a href="$&">$&</a>').replace(pseudoUrlPattern, '$1<a href="http://$2">$2</a>');
+        var out = pref + str.replace(urlPattern, '<a href="$&">$&</a>').replace(pseudoUrlPattern, '$1<a href="http://$2">$2</a>');
+
+        console.log("makeUrl", str, out);
+        return out;
     }
 
     function isUrl(str) {
-        return str.match(/^(https?:\/\/)?([\da-z\.-]+)\.([a-z]{2,6})([\/\w \.-]*)*\/?$/)
+        var result = str.match(/^ ?(https?:\/\/)?([\da-z\.-]+)\.([a-z]{2,6})([\/\w \.-]*)*\/?$/);
+        console.log("isUrl", str, result);
+        return result
     }
 
     Flow {
@@ -111,6 +122,7 @@ Item {
         color: Styles.textColor
         font.pixelSize: fontSize
         text: "<font color=\""+chat.colors[user]+"\"><a href=\"user:%1\"><b>%1</b></a></font>".arg(user) + (isAction? "&nbsp;": ":&nbsp;")
+        onLinkActivated: userLinkActivation(link)
       }
 
       Repeater {
@@ -154,6 +166,7 @@ Item {
         text: makeUrl(msgItem)
         textFormat: Text.RichText
         wrapMode: Text.WordWrap
+        onLinkActivated: externalLinkActivation(link)
       }
     }
     property Component imgThing: Component {
@@ -164,6 +177,33 @@ Item {
         asynchronous: true
       }
     }
+
+    function userLinkActivation(link)
+    {
+        if (link.substr(0,5) === "user:")
+        {
+            var value = "@"+link.replace('user:',"")+', '
+            if (_input.text === "")
+            {
+                _input.text = value
+            }
+            else {
+                _input.text = _input.text + ' '+ value
+            }
+
+        }
+    }
+
+    function externalLinkActivation(link)
+    {
+        console.log("externalLinkActivation", link, "passed");
+        if (link.substr(0,5) !== "user:")
+        {
+            console.log("opening link")
+            Qt.openUrlExternally(link)
+        }
+    }
+
     /*
     Text {
         id: _text

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -23,9 +23,11 @@ Item {
     property string user
     property var msg
     property bool isAction
+    property string jsonBadgeEntries
     property string emoteDirPath
     property int fontSize: Styles.titleFont.smaller
     property var pmsg: JSON.parse(msg)
+    property var badgeEntries: JSON.parse(jsonBadgeEntries)
 
     height: childrenRect.height
 
@@ -116,6 +118,7 @@ Item {
     }
 
     CustomFlow {
+      id: _messageLineFlow
       ySpacing: 1
       anchors {
           left: parent.left
@@ -123,6 +126,17 @@ Item {
       }
 
       vAlign: vAlignCenter
+
+      Repeater {
+        model: badgeEntries
+
+        Loader {
+          property var badgeEntry: badgeEntries[index]
+          sourceComponent: {
+            return badgeItem
+          }
+        }
+      }
 
       Text {
         id: userName
@@ -190,6 +204,33 @@ Item {
             ToolTip {
                 visible: _emoteImgMouseArea.containsMouse && msgItem.emoteText != null
                 text: msgItem.emoteText
+            }
+          }
+      }
+    }
+
+    property Component badgeItem: Component {
+      MouseArea {
+          id: _badgeImgMouseArea
+          hoverEnabled: true
+          width: _badgeImg.width + dp(2)
+          height: _badgeImg.height
+          Image {
+            id: _badgeImg
+            // synchronous to simplify CustomFlow
+            Component.onCompleted: {
+              source = badgeEntry.url;
+            }
+
+            onStatusChanged: {
+                if (status == Image.Ready) {
+                    _messageLineFlow.updatePositions();
+                }
+            }
+
+            ToolTip {
+                visible: _badgeImgMouseArea.containsMouse && badgeEntry.name != null
+                text: badgeEntry.name
             }
           }
       }

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -124,10 +124,13 @@ Item {
           property var msgItem: pmsg[index]
           sourceComponent: {
             if(typeof pmsg[index] == "string") {
-              return msgText
-            }
-            else {
-              return imgThing
+              if (isUrl(pmsg[index])) {
+                return msgLink;
+              } else {
+                return msgText;
+              }
+            } else {
+              return imgThing;
             }
           }
         }
@@ -140,6 +143,16 @@ Item {
         color: isAction? chat.colors[user] : Styles.textColor
         font.pixelSize: fontSize
         text: msgItem
+        wrapMode: Text.WordWrap
+      }
+    }
+    property Component msgLink: Component {
+      Text {
+        verticalAlignment: Text.AlignVCenter
+        color: isAction? chat.colors[user] : Styles.textColor
+        font.pixelSize: fontSize
+        text: makeUrl(msgItem)
+        textFormat: Text.RichText
         wrapMode: Text.WordWrap
       }
     }

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -30,10 +30,14 @@ Item {
     property int fontSize: Styles.titleFont.smaller
     property var pmsg: JSON.parse(msg)
     property var badgeEntries: JSON.parse(jsonBadgeEntries)
-    property var visibleBadgeEntries: userName.visible? badgeEntries : []
     property var highlightOpacity: 1.0
 
     property string systemMessageBackgroundColor: "#333333"
+
+    property bool showUsernameLine: !isChannelNotice || !systemMessage || (pmsg && pmsg.length > 0)
+    property bool showSystemMessageLine: isChannelNotice && systemMessage != ""
+
+    property var visibleBadgeEntries: showUsernameLine? badgeEntries : []
 
     height: childrenRect.height
 
@@ -143,13 +147,13 @@ Item {
             right: parent.right
         }
 
-        visible: root.isChannelNotice && root.systemMessage != ""
+        visible: showSystemMessageLine
         color: Styles.textColor
         text: root.systemMessage
         font.pixelSize: fontSize
         wrapMode: Text.WordWrap
 
-        height: visible? contentHeight : 0
+        height: showSystemMessageLine? contentHeight : 0
     }
 
     CustomFlow {
@@ -177,14 +181,14 @@ Item {
       Text {
         id: userName
         // if this ChatMessage is a channel notice with no user message text, don't show a user chat line
-        visible: !root.isChannelNotice || !root.systemMessage || (pmsg && pmsg.length > 0)
+        visible: showUsernameLine
         verticalAlignment: Text.AlignVCenter
         color: Styles.textColor
         font.pixelSize: fontSize
         text: "<font color=\""+chat.colors[user]+"\"><a href=\"user:%1\"><b>%1</b></a></font>".arg(user) + (isAction? "&nbsp;": ":&nbsp;")
         onLinkActivated: userLinkActivation(link)
 
-        height: visible? contentHeight : 0
+        height: showUsernameLine? contentHeight : 0
 
         MouseArea {
             anchors.fill: parent

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -30,6 +30,7 @@ Item {
     property int fontSize: Styles.titleFont.smaller
     property var pmsg: JSON.parse(msg)
     property var badgeEntries: JSON.parse(jsonBadgeEntries)
+    property var visibleBadgeEntries: visible? badgeEntries : []
     property var highlightOpacity: 1.0
 
     property string systemMessageBackgroundColor: "#333333"
@@ -148,11 +149,7 @@ Item {
         font.pixelSize: fontSize
         wrapMode: Text.WordWrap
 
-        Component.onCompleted: {
-            if (!_systemMessageLine.visible) {
-                _systemMessageLine.height = 0;
-            }
-        }
+        height: visible? contentHeight : 0
     }
 
     CustomFlow {
@@ -167,10 +164,10 @@ Item {
       vAlign: vAlignCenter
 
       Repeater {
-        model: badgeEntries
+        model: visibleBadgeEntries
 
         Loader {
-          property var badgeEntry: badgeEntries[index]
+          property var badgeEntry: visibleBadgeEntries[index]
           sourceComponent: {
             return badgeItem
           }
@@ -187,13 +184,7 @@ Item {
         text: "<font color=\""+chat.colors[user]+"\"><a href=\"user:%1\"><b>%1</b></a></font>".arg(user) + (isAction? "&nbsp;": ":&nbsp;")
         onLinkActivated: userLinkActivation(link)
 
-        Component.onCompleted: {
-            console.log("username complete", isChannelNotice, systemMessage, pmsg, pmsg.length)
-            if (!userName.visible) {
-                userName.height = 0;
-                badgeEntries = [];
-            }
-        }
+        height: visible? contentHeight : 0
 
         MouseArea {
             anchors.fill: parent

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -682,17 +682,18 @@ Item {
             var imageFormatToUse = "image";
 
             console.log("badges for this message:")
-            for (var i in badges) {
-                console.log("  badge", i, badges[i]);
-                var versionStr = badges[i];
+            for (var k = 0; k < badges.length; k++) {
+                var badgeName = badges[k][0];
+                var versionStr = badges[k][1];
+                console.log("  badge", badgeName, versionStr);
 
                 var curBadgeAdded = false;
 
-                var badgeSetData = lastBetaBadgeSetData[i];
+                var badgeSetData = lastBetaBadgeSetData[badgeName];
                 if (badgeSetData != null) {
                     var versionObj = badgeSetData[versionStr];
                     if (versionObj == null) {
-                        console.log("  beta badge set for", i, "has no version entry for", versionStr);
+                        console.log("  beta badge set for", badgeName, "has no version entry for", versionStr);
                         console.log("  available versions are", keysStr(badgeSetData))
                     } else {
                         var entry = {"name": versionObj.title, "url": versionObj.image_url_1x, "click_action": versionObj.click_action, "click_url": versionObj.click_url}
@@ -702,21 +703,21 @@ Item {
                     }
                 }
 
-                var badgeUrls = lastBadgeUrls[i];
+                var badgeUrls = lastBadgeUrls[badgeName];
                 if (!curBadgeAdded && badgeUrls != null) {
                     console.log("  badge urls:")
                     for (var j in badgeUrls) {
                         console.log("    key", j, "value", badgeUrls[j]);
                     }
                     var url = badgeUrls[imageFormatToUse];
-                    var entry = {"name": i, "url": url};
+                    var entry = {"name": badgeName, "url": url};
                     console.log("adding entry", JSON.stringify(entry));
                     badgeEntries.push(entry);
                     curBadgeAdded = true;
                 }
 
                 if (!curBadgeAdded) {
-                    console.log("  Unknown badge", i);
+                    console.log("  Unknown badge", badgeName);
                 }
             }
 

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -652,6 +652,14 @@ Item {
             emoteDirPath = value
         }
 
+        function keysStr(obj) {
+            var parts = [];
+            for (var i in obj) {
+                parts.push(i);
+            }
+            return parts.join(", ");
+        }
+
         onMessageReceived: {
             //console.log("ChatView chat override onMessageReceived; typeof message " + typeof(message) + " toString: " + message.toString())
 
@@ -682,6 +690,7 @@ Item {
                     var versionObj = badgeSetData[versionStr];
                     if (versionObj == null) {
                         console.log("  beta badge set for", i, "has no version entry for", versionStr);
+                        console.log("  available versions are", keysStr(badgeSetData))
                     } else {
                         var entry = {"name": versionObj.title, "url": versionObj.image_url_1x, "click_action": versionObj.click_action, "click_url": versionObj.click_url}
                         console.log("adding entry", JSON.stringify(entry));
@@ -744,8 +753,8 @@ Item {
         }
 
         onChannelBadgeBetaUrlsLoaded: {
-            console.log("onChannelBadgeBetaUrlsLoaded for channel", channel, "current channel is", chat.channel);
-            if (channel == chat.channel) {
+            console.log("onChannelBadgeBetaUrlsLoaded for channel", channel, "current channel is", chat.channelId.toString());
+            if (channel == chat.channelId.toString()) {
                 console.log("saving lastBetaBadgeUrls", badgeSetData)
                 lastChannelBetaBadgeSetData = badgeSetData;
             }

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -158,6 +158,7 @@ Item {
             emoteDirPath: chat.emoteDirPath
             isChannelNotice: model.isChannelNotice
             systemMessage: model.systemMessage
+            highlightOpacity: root._opacity
 
             anchors {
                 left: parent.left

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -505,7 +505,8 @@ Item {
 
                     try {
                         var r = new RegExp(s);
-                        testFailed = r.exec(out) == null;
+                        var match = r.exec(out);
+                        testFailed = match == null || match[0] != out;
                     } catch (e) {
                         console.log(e, out);
                         testFailed = true;
@@ -614,7 +615,8 @@ Item {
                 for (var emoteIdStr in entry) {
                     var emoteId = parseInt(emoteIdStr);
                     var emoteText = entry[emoteIdStr];
-                    if (plainText.exec(emoteText)) {
+                    var match = plainText.exec(emoteText);
+                    if (match && match[0] == emoteText) {
                         //console.log("adding plain text emote", emoteText, emoteId);
                         _textEmotesMap[emoteText] = emoteId;
                     } else {
@@ -632,7 +634,8 @@ Item {
             }
             for (var i = 0; i < _regexEmotesList.length; i++) {
                 var entry = _regexEmotesList[i];
-                if (entry.regex.exec(word)) {
+                var match = entry.regex.exec(word);
+                if (match && match[0] == word) {
                     return entry.emoteId;
                 }
             }

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -680,12 +680,19 @@ Item {
 
             var badgeEntries = [];
             var imageFormatToUse = "image";
+            var badgesSeen = {};
 
             console.log("badges for this message:")
             for (var k = 0; k < badges.length; k++) {
                 var badgeName = badges[k][0];
                 var versionStr = badges[k][1];
                 console.log("  badge", badgeName, versionStr);
+
+                if (badgesSeen[badgeName]) {
+                    continue;
+                } else {
+                    badgesSeen[badgeName] = true;
+                }
 
                 var curBadgeAdded = false;
 

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -92,6 +92,7 @@ Item {
     function loadEmotes() {
         //console.log("loadEmotes()", chat.lastEmoteSets);
         if (chat.lastEmoteSets) {
+            _emotePicker.loading = true;
             //console.log("downloading chat.lastEmoteSets", chat.lastEmoteSets);
             _emoteButton.startDownload(chat.lastEmoteSets);
         }

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -98,6 +98,8 @@ Item {
         delegate: ChatMessage {
             user: model.user
             msg: model.message
+            isAction: model.isAction
+            emoteDirPath: chat.emoteDirPath
 
             anchors {
                 left: parent.left
@@ -184,6 +186,8 @@ Item {
         id: chat
 
         property variant colors:[]
+        property string emoteDirPath
+
         function getRandomColor() {
             var letters = '0123456789ABCDEF';
             var color = '#';
@@ -193,7 +197,13 @@ Item {
             return color;
         }
 
+        onSetEmotePath: {
+            emoteDirPath = value
+        }
+
         onMessageReceived: {
+            //console.log("ChatView chat override onMessageReceived; typeof message " + typeof(message) + " toString: " + message.toString())
+
             if (chatColor != "") {
                 colors[user] = chatColor;
             }
@@ -202,7 +212,10 @@ Item {
                 colors[user] = getRandomColor()
             }
 
-            chatModel.append({"user": user, "message": message})
+            // ListElement doesn't support putting in an array value, ugh.
+            var serializedMessage = JSON.stringify(message);
+            //console.log("Sending: " + serializedMessage);
+            chatModel.append({"user": user, "message": serializedMessage, "isAction": isAction})
             list.scrollbuf = 6
         }
 

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -198,7 +198,41 @@ Item {
     GridPicker {
         id: _emotePicker
 
-        height: dp(320)
+        visible: false
+        height: 0
+
+        onVisibleChanged: {
+            if (visible) {
+                height = dp(320);
+            }
+        }
+
+        function startClosing() {
+            //visible = false;
+            height = 0;
+            _emotePickerCloseTimer.start();
+        }
+
+        onCloseRequested: {
+            startClosing();
+            _input.focus = true;
+        }
+
+        Behavior on height {
+            NumberAnimation {
+                duration: 200
+                easing.type: Easing.OutCubic
+            }
+        }
+
+        Timer {
+            id: _emotePickerCloseTimer
+            interval: 200
+            repeat: false
+            onTriggered: {
+                _emotePicker.visible = false
+            }
+        }
 
         color: "#ffffff"
 
@@ -209,7 +243,6 @@ Item {
         }
 
         model: _emoteButton.setsVisible
-        visible: false
         text: "Emote Picker"
 
         filterTextProperty: "emoteName"
@@ -217,11 +250,6 @@ Item {
         onItemClicked: {
             var item = _emoteButton.setsVisible.get(index);
             _emoteButton.addEmoteToChat(item.emoteName);
-        }
-
-        onCloseRequested: {
-            visible = false;
-            _input.focus = true;
         }
 
         onMoveFocusDown: {
@@ -332,7 +360,11 @@ Item {
                 }
 
                 onClicked: {
-                    _emotePicker.visible = !_emotePicker.visible;
+                    if (_emotePicker.visible) {
+                        _emotePicker.startClosing();
+                    } else {
+                        _emotePicker.visible = true;
+                    }
                 }
 
                 function addEmoteToChat(emoteName) {

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -35,6 +35,7 @@ Item {
     visible: status > 0
 
     property real _opacity: root.status > 1 ? 0.6 : 1.0
+    property int chatWidth: width
 
     Rectangle {
         anchors.fill: parent
@@ -166,10 +167,11 @@ Item {
             }
         }
 
+        width: chatWidth
+
         anchors {
             top: parent.top
             left: parent.left
-            right: parent.right
             bottom: spacer.top
         }
 

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -156,6 +156,8 @@ Item {
             jsonBadgeEntries: model.jsonBadgeEntries
             isAction: model.isAction
             emoteDirPath: chat.emoteDirPath
+            isChannelNotice: model.isChannelNotice
+            systemMessage: model.systemMessage
 
             anchors {
                 left: parent.left
@@ -730,7 +732,7 @@ Item {
 
             var jsonBadgeEntries = JSON.stringify(badgeEntries);
 
-            chatModel.append({"user": user, "message": serializedMessage, "isAction": isAction, "jsonBadgeEntries": jsonBadgeEntries})
+            chatModel.append({"user": user, "message": serializedMessage, "isAction": isAction, "jsonBadgeEntries": jsonBadgeEntries, "isChannelNotice": isChannelNotice, "systemMessage": systemMessage})
             list.scrollbuf = 6
         }
 

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -243,7 +243,6 @@ Item {
         }
 
         model: _emoteButton.setsVisible
-        text: "Emote Picker"
 
         filterTextProperty: "emoteName"
 

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -188,7 +188,7 @@ Item {
             var letters = '0123456789ABCDEF';
             var color = '#';
             for (var i = 0; i < 6; i++ ) {
-                color += letters[Math.floor(Math.random() * 16)];
+                color += letters[Math.floor(Math.random() * (letters.length - 1))];
             }
             return color;
         }

--- a/src/util/jsonparser.cpp
+++ b/src/util/jsonparser.cpp
@@ -448,6 +448,29 @@ QMap<int, QMap<int, QString>> JsonParser::parseEmoteSets(const QByteArray &data)
     return out;
 }
 
+QMap<QString, QMap<QString, QString>> JsonParser::parseChannelBadgeUrls(const QByteArray &data) {
+    QMap<QString, QMap<QString, QString>> out;
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(data, &error);
+
+    if (error.error == QJsonParseError::NoError) {
+        QJsonObject json = doc.object();
+        for (auto badgeEntry = json.begin(); badgeEntry != json.end(); badgeEntry++) {
+            if (badgeEntry.value().isNull()) continue;
+            QMap<QString, QString> urls;
+            QJsonObject badgeEntryJson = badgeEntry.value().toObject();
+            for (auto urlEntry = badgeEntryJson.begin(); urlEntry != badgeEntryJson.end(); urlEntry++) {
+                urls.insert(urlEntry.key(), urlEntry.value().toString());
+            }
+            out.insert(badgeEntry.key(), urls);
+        }
+    }
+            
+    return out;
+}
+
+
 int JsonParser::parseTotal(const QByteArray &data)
 {
     int total = 0;

--- a/src/util/jsonparser.h
+++ b/src/util/jsonparser.h
@@ -51,6 +51,7 @@ public:
     static int parseTotal(const QByteArray&);
     static QMap<int, QMap<int, QString>> parseEmoteSets(const QByteArray&);
     static QMap<QString, QMap<QString, QString>> parseChannelBadgeUrls(const QByteArray &data);
+    static QMap<QString, QMap<QString, QMap<QString, QString>>> parseBadgeUrlsBetaFormat(const QByteArray &data);
 };
 
 #endif // JSONPARSER_H

--- a/src/util/jsonparser.h
+++ b/src/util/jsonparser.h
@@ -50,6 +50,7 @@ public:
     static QString parseUserName(const QByteArray&);
     static int parseTotal(const QByteArray&);
     static QMap<int, QMap<int, QString>> parseEmoteSets(const QByteArray&);
+    static QMap<QString, QMap<QString, QString>> parseChannelBadgeUrls(const QByteArray &data);
 };
 
 #endif // JSONPARSER_H


### PR DESCRIPTION
I could go on improving this forever probably but I might as well get a PR going for the work so far.

This adds:
- Display of Twitch emotes in chat, in sent and received messages
- Emote picker w/ search and keyboard controls
- Display users' Twitch badges from both APIs
- Tooltips for emotes & badges
- Add USERNOTICE support,
- Display channel notices closer to the look of the Twitch web-based chat

Kudos to @mroNNorm for the initial emote work, putting together the skeleton of the emote downloads & Flow/Repeater-based chat UI.

This should address https://github.com/alamminsalo/orion/issues/10 & https://github.com/alamminsalo/orion/issues/77 & https://github.com/alamminsalo/orion/issues/68