### PR TITLE
Eliminate unneeded extra stream checks

### DIFF
--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -595,11 +595,11 @@ void ChannelManager::addFollowedResults(const QList<Channel *> &list, const quin
     if (list.size() == FOLLOWED_FETCH_LIMIT)
         getFollowedChannels(FOLLOWED_FETCH_LIMIT, offset);
 
+    checkStreams(list);
+
     qDeleteAll(list);
 
     emit followedUpdated();
-
-    checkFavourites();
 }
 
 void ChannelManager::onNetworkAccessChanged(bool up)


### PR DESCRIPTION
When a batch of followed channels arrives, check only that batch of channels for streams, not all the batches of followed channels that have arrived so far.

The multiple updates arriving because of this appears to be the underlying cause of what I was seeing in https://github.com/alamminsalo/orion/issues/73