### PR TITLE
Badges image provider

### DIFF
--- a/orion.pro
+++ b/orion.pro
@@ -30,7 +30,8 @@ SOURCES += src/main.cpp\
     src/model/vodlistmodel.cpp \
     src/model/vodmanager.cpp \
     src/notification/notificationmanager.cpp \
-    src/model/ircchat.cpp
+    src/model/ircchat.cpp \
+    src/model/imageprovider.cpp
 
 
 HEADERS  += src/model/channel.h \
@@ -51,7 +52,8 @@ HEADERS  += src/model/channel.h \
     src/model/vodmanager.h \
     src/network/urls.h \
     src/notification/notificationmanager.h \
-    src/model/ircchat.h
+    src/model/ircchat.h \
+    src/model/imageprovider.h
 
 #Backend for player, uses mpv as default
 !qtav: !multimedia {

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -41,11 +41,11 @@ QString BadgeImageProvider::getCanonicalKey(QString key) {
         if (_channelManager->getChannelBadgeBetaUrl(_channelId, badge, version, betaImageFormat, url)) {
             return QList<QString>({ _channelId, badge, version, betaImageFormat }).join("-");
         }
-        if (_channelManager->getChannelBadgeUrl(_channelName, badge, officialImageFormat, url)) {
-            return QList<QString>({ _channelName, badge, officialImageFormat }).join("-");
-        }
         if (_channelManager->getChannelBadgeBetaUrl("GLOBAL", badge, version, betaImageFormat, url)) {
             return QList<QString>({ "GLOBAL", badge, version, betaImageFormat }).join("-");
+        }
+        if (_channelManager->getChannelBadgeUrl(_channelName, badge, officialImageFormat, url)) {
+            return QList<QString>({ _channelName, badge, officialImageFormat }).join("-");
         }
         if (_channelManager->getChannelBadgeUrl("GLOBAL", badge, officialImageFormat, url)) {
             return QList<QString>({ "GLOBAL", badge, officialImageFormat }).join("-");

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -21,6 +21,60 @@
 #include <QApplication>
 #include <QStandardPaths>
 
+BadgeImageProvider::BadgeImageProvider(ChannelManager * channelManager) : ImageProvider("badge", ".png"), _channelManager(channelManager) {
+    
+}
+
+QString BadgeImageProvider::getCanonicalKey(QString key) {
+    /** Resolve a key with just a badge name and version, specific to the current room, to a globally unique key for an official API or beta API badge */
+    QString url;
+
+    const QString betaImageFormat = "image_url_1x";
+    const QString officialImageFormat = "image";
+
+    int splitPos = key.indexOf("-");
+    if (splitPos != -1) {
+        const QString badge = key.left(splitPos);
+        const QString version = key.mid(splitPos + 1);
+        qDebug() << "badge hunt: channel name" << _channelName << "channel id" << _channelId << "badge" << badge << "version" << version;
+
+        if (_channelManager->getChannelBadgeBetaUrl(_channelId, badge, version, betaImageFormat, url)) {
+            return QList<QString>({ _channelId, badge, version, betaImageFormat }).join("-");
+        }
+        if (_channelManager->getChannelBadgeUrl(_channelName, badge, officialImageFormat, url)) {
+            return QList<QString>({ _channelName, badge, officialImageFormat }).join("-");
+        }
+        if (_channelManager->getChannelBadgeBetaUrl("GLOBAL", badge, version, betaImageFormat, url)) {
+            return QList<QString>({ "GLOBAL", badge, version, betaImageFormat }).join("-");
+        }
+        if (_channelManager->getChannelBadgeUrl("GLOBAL", badge, officialImageFormat, url)) {
+            return QList<QString>({ "GLOBAL", badge, officialImageFormat }).join("-");
+        }
+    }
+
+    qDebug() << "getCanonicalKey for badge" << key << "could not find a badge";
+}
+
+const QUrl BadgeImageProvider::getUrlForKey(QString & key) {
+    QString url;
+
+    QList<QString> parts = key.split("-");
+    if (parts.length() == 3) {
+        if (_channelManager->getChannelBadgeUrl(parts[0], parts[1], parts[2], url)) {
+            return url;
+        }
+    }
+    else if (parts.length() == 4) {
+        if (_channelManager->getChannelBadgeBetaUrl(parts[0], parts[1], parts[2], parts[3], url)) {
+            return url;
+        }
+    }
+    else {
+        qDebug() << "Invalid badge cache key" << key;
+        return QUrl();
+    }
+}
+
 ChannelListModel *ChannelManager::createFollowedChannelsModel()
 {
     ChannelListModel *model = new ChannelListModel();
@@ -31,7 +85,7 @@ ChannelListModel *ChannelManager::createFollowedChannelsModel()
     return model;
 }
 
-ChannelManager::ChannelManager(NetworkManager *netman) : netman(netman){
+ChannelManager::ChannelManager(NetworkManager *netman) : netman(netman), badgeImageProvider(this) {
     access_token = "";
     tempFavourites = 0;
 

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -183,7 +183,7 @@ void DownloadHandler::replyFinished() {
     QNetworkReply* _reply = qobject_cast<QNetworkReply*>(sender());
     if (_reply) {
         _reply->deleteLater();
-        _file.close();
+        _file.commit();
         //qDebug() << _file.fileName();
         //might need something for windows for the forwardslash..
         qDebug() << "download of" << _file.fileName() << "complete";

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2015-2016 Antti Lamminsalo
+ *
+ * This file is part of Orion.
+ *
+ * Orion is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orion.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <QString>
+#include <QUrl>
+#include <QtGlobal>
+#include <QDebug>
+#include <QNetworkRequest>
+#include "imageprovider.h"
+
+ImageProvider::ImageProvider(const QString imageProviderName, const QString urlFormat, const QDir cacheDir, const QString extension) : 
+    _imageProviderName(imageProviderName), _urlFormat(urlFormat), _cacheDir(cacheDir), _extension(extension) {
+
+    activeDownloadCount = 0;
+}
+
+ImageProvider::~ImageProvider() {
+    qDeleteAll(_imageTable);
+}
+
+bool ImageProvider::makeAvailable(QString key) {
+    /* Make emote available by downloading it or loading it from cache if not already loaded.
+    * Returns true if caller should wait for a downloadComplete event before using the emote */
+    if (currentlyDownloading.contains(key)) {
+        // download of this emote in progress
+        return true;
+    }
+    else if (download(key)) {
+        // if this emote isn't already downloading, it's safe to load the cache file or download if not in the cache
+        currentlyDownloading.insert(key);
+        activeDownloadCount += 1;
+        return true;
+    }
+    else {
+        // we already had the emote locally and don't need to wait for it to download
+        return false;
+    }
+}
+
+bool ImageProvider::download(QString key) {
+    if (_imageTable.contains(key)) {
+        qDebug() << "already in the table";
+        return false;
+    }
+
+    QUrl url = _urlFormat.arg(key);
+    _cacheDir.mkpath(".");
+
+    QString filename = _cacheDir.absoluteFilePath(key + _extension);
+
+    if (_cacheDir.exists(key + _extension)) {
+        //qDebug() << "local file already exists";
+        loadImageFile(key, filename);
+        return false;
+    }
+    qDebug() << "downloading";
+
+    QNetworkRequest request(url);
+    QNetworkReply* _reply = nullptr;
+    _reply = _manager.get(request);
+
+    DownloadHandler * dh = new DownloadHandler(filename, key);
+
+    connect(_reply, &QNetworkReply::readyRead,
+        dh, &DownloadHandler::dataAvailable);
+    connect(_reply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error),
+        dh, &DownloadHandler::error);
+    connect(_reply, &QNetworkReply::finished,
+        dh, &DownloadHandler::replyFinished);
+    connect(dh, &DownloadHandler::downloadComplete,
+        this, &ImageProvider::individualDownloadComplete);
+
+    return true;
+}
+
+bool ImageProvider::bulkDownload(QList<QString> keys) {
+    bool waitForDownloadComplete = false;
+    for (auto key : keys) {
+        if (makeAvailable(key)) {
+            waitForDownloadComplete = true;
+        }
+    }
+    return waitForDownloadComplete;
+}
+
+
+void ImageProvider::individualDownloadComplete(QString filename, bool hadError) {
+    DownloadHandler * dh = qobject_cast<DownloadHandler*>(sender());
+    const QString emoteKey = dh->getKey();
+    delete dh;
+
+    if (hadError) {
+        // delete partial download if any
+        QFile(filename).remove();
+    }
+    else {
+        loadImageFile(emoteKey, filename);
+    }
+
+    if (activeDownloadCount > 0) {
+        activeDownloadCount--;
+        qDebug() << activeDownloadCount << "active downloads remaining";
+    }
+
+    currentlyDownloading.remove(emoteKey);
+
+    if (activeDownloadCount == 0) {
+        emit downloadComplete();
+    }
+}
+
+QHash<QString, QImage*> ImageProvider::imageTable() {
+    return _imageTable;
+}
+
+void ImageProvider::loadImageFile(QString emoteKey, QString filename) {
+    QImage* emoteImg = new QImage();
+    //qDebug() << "loading" << filename;
+    emoteImg->load(filename);
+    _imageTable.insert(emoteKey, emoteImg);
+}
+
+QQmlImageProviderBase * ImageProvider::getQMLImageProvider() {
+    return new CachedImageProvider(_imageTable);
+}
+
+bool ImageProvider::downloadsInProgress() {
+    return activeDownloadCount > 0;
+}
+
+// DownloadHandler
+
+DownloadHandler::DownloadHandler(QString filename, QString key) : filename(filename), key(key), hadError(false) {
+    _file.setFileName(filename);
+    _file.open(QFile::WriteOnly);
+    qDebug() << "starting download of" << filename;
+}
+
+void DownloadHandler::dataAvailable() {
+    QNetworkReply* _reply = qobject_cast<QNetworkReply*>(sender());
+    auto buffer = _reply->readAll();
+    _file.write(buffer.data(), buffer.size());
+}
+
+void DownloadHandler::error(QNetworkReply::NetworkError code) {
+    hadError = true;
+    QNetworkReply* _reply = qobject_cast<QNetworkReply*>(sender());
+    qDebug() << "Network error downloading" << filename << ":" << _reply->errorString();
+}
+
+void DownloadHandler::replyFinished() {
+    QNetworkReply* _reply = qobject_cast<QNetworkReply*>(sender());
+    if (_reply) {
+        _reply->deleteLater();
+        _file.close();
+        //qDebug() << _file.fileName();
+        //might need something for windows for the forwardslash..
+        qDebug() << "download of" << _file.fileName() << "complete";
+
+        emit downloadComplete(_file.fileName(), hadError);
+    }
+}
+
+
+// CachedImageProvider
+CachedImageProvider::CachedImageProvider(QHash<QString, QImage*> & imageTable) : QQuickImageProvider(QQuickImageProvider::Image), imageTable(imageTable) {
+
+}
+
+QImage CachedImageProvider::requestImage(const QString &id, QSize * size, const QSize & requestedSize) {
+    //qDebug() << "Requested id" << id << "from image provider";
+    QImage * entry = NULL;
+    auto result = imageTable.find(id);
+    if (result != imageTable.end()) {
+        entry = *result;
+    }
+    if (entry) {
+        if (size) {
+            *size = entry->size();
+        }
+        return *entry;
+    }
+    return QImage();
+}

--- a/src/model/imageprovider.h
+++ b/src/model/imageprovider.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015-2016 Antti Lamminsalo
+ *
+ * This file is part of Orion.
+ *
+ * Orion is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orion.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef IMAGEPROVIDER_H
+#define IMAGEPROVIDER_H
+
+#include <QString>
+#include <QDir>
+#include <QHash>
+#include <QImage>
+#include <QSet>
+#include <QObject>
+#include <QQuickImageProvider>
+#include <QNetworkReply>
+
+// Handles state for an individual download
+class DownloadHandler : public QObject
+{
+    Q_OBJECT
+public:
+    DownloadHandler(const QString filename, const QString key);
+private:
+    const QString filename;
+    const QString key;
+    QFile _file;
+    bool hadError;
+
+signals:
+    void downloadComplete(QString filename, bool hadError);
+
+public slots:
+    void dataAvailable();
+    void replyFinished();
+    void error(QNetworkReply::NetworkError code);
+    const QString getKey() { return key; }
+};
+
+// provides QImages to QML frontend
+class CachedImageProvider : public QQuickImageProvider {
+public:
+    CachedImageProvider(QHash<QString, QImage*> & imageTable);
+    QImage requestImage(const QString &id, QSize * size, const QSize & requestedSize);
+private:
+    QHash<QString, QImage*> & imageTable;
+};
+
+// interface to QML
+class ImageProvider : public QObject {
+    Q_OBJECT
+public:
+    ImageProvider(const QString imageProviderName, const QString urlFormat, const QDir cacheDir, const QString extension);
+    ~ImageProvider();
+
+    QString getImageProviderName() { return _imageProviderName;  }
+    QString getBaseUrl() { return "image://" + _imageProviderName; }
+    bool makeAvailable(QString key);
+    bool download(QString key);
+    bool downloadsInProgress();
+
+    QHash<QString, QImage*> imageTable();
+    void loadImageFile(QString key, QString filename);
+
+    QQmlImageProviderBase * getQMLImageProvider();
+signals:
+    void downloadComplete();
+
+public slots:
+    bool bulkDownload(QList<QString> keys);
+    void individualDownloadComplete(QString filename, bool hadError);
+
+private:
+    QNetworkAccessManager _manager;
+
+    QHash<QString, QImage*> _imageTable;
+    QString _imageProviderName;
+    QString _urlFormat;
+    QDir _cacheDir;
+    int activeDownloadCount;
+    QString _extension;
+    QSet<QString> currentlyDownloading;
+};
+
+#endif

--- a/src/model/imageprovider.h
+++ b/src/model/imageprovider.h
@@ -15,12 +15,13 @@
 #ifndef IMAGEPROVIDER_H
 #define IMAGEPROVIDER_H
 
+#include <QObject>
+#include <QSaveFile>
 #include <QString>
 #include <QDir>
 #include <QHash>
 #include <QImage>
 #include <QSet>
-#include <QObject>
 #include <QQuickImageProvider>
 #include <QNetworkReply>
 
@@ -33,7 +34,7 @@ public:
 private:
     const QString filename;
     const QString key;
-    QFile _file;
+    QSaveFile _file;
     bool hadError;
 
 signals:

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -35,6 +35,7 @@ Item {
     property var singleShot: undefined
 
     Component.onCompleted: {
+        chat.hookupChannelProviders(g_cman)
         chat.initProviders()
     }
 
@@ -61,7 +62,7 @@ Item {
     }
 
     function joinChannel(channelName, channelId) {
-        chat.join(channelName)
+        chat.join(channelName, channelId)
         root.channel = channelName
         root.channelId = channelId
         messageReceived("notice", null, "", false, false, false, [], true, "Joined channel #" + channelName)
@@ -85,6 +86,10 @@ Item {
         leaveChannel()
         if (root.channel)
             joinChannel(root.channel, root.channelId)
+    }
+
+    function getBadgeLocalUrl(key) {
+        return chat.getBadgeLocalUrl(key);
     }
 
     IrcChat {

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -727,6 +727,8 @@ Item {
 
                 var curBadgeAdded = false;
 
+                var badgeLocalUrl = chat.getBadgeLocalUrl(badgeName + "-" + versionStr);
+
                 var badgeSetData = lastBetaBadgeSetData[badgeName];
                 if (badgeSetData != null) {
                     var versionObj = badgeSetData[versionStr];
@@ -734,7 +736,7 @@ Item {
                         console.log("  beta badge set for", badgeName, "has no version entry for", versionStr);
                         console.log("  available versions are", keysStr(badgeSetData))
                     } else {
-                        var entry = {"name": versionObj.title, "url": versionObj.image_url_1x, "click_action": versionObj.click_action, "click_url": versionObj.click_url}
+                        var entry = {"name": versionObj.title, "url": badgeLocalUrl, "click_action": versionObj.click_action, "click_url": versionObj.click_url}
                         console.log("adding entry", JSON.stringify(entry));
                         badgeEntries.push(entry);
                         curBadgeAdded = true;
@@ -747,8 +749,7 @@ Item {
                     for (var j in badgeUrls) {
                         console.log("    key", j, "value", badgeUrls[j]);
                     }
-                    var url = badgeUrls[imageFormatToUse];
-                    var entry = {"name": badgeName, "url": url};
+                    var entry = {"name": badgeName, "url": badgeLocalUrl};
                     console.log("adding entry", JSON.stringify(entry));
                     badgeEntries.push(entry);
                     curBadgeAdded = true;


### PR DESCRIPTION
- Refactor image download and `QQuickImageProvider` (from emotes implementation) out to the `ImageProvider`
- Use `ImageProvider` for badges also, so we preload badge images and buffer chat until loaded (gets rid of the layout jitter due to the current badges URLs used directly in QML)
- Switch to downloading to use `QSaveFile` (writing to a temp file that gets renamed once complete)