### PR TITLE
Make grids usable from touch screen 

### DIFF
--- a/src/qml/GamesView.qml
+++ b/src/qml/GamesView.qml
@@ -209,6 +209,22 @@ Item {
             _menu.popup()
         }
 
+        onItemTooltipHover: {
+            g_tooltip.text = ""
+
+            if (selectedItem.title){
+                g_tooltip.text += selectedItem.title
+            }
+
+            if (selectedItem.viewers){
+                g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
+                g_tooltip.text += selectedItem.viewers + " viewers"
+            }
+
+            g_tooltip.img = selectedItem.preview
+            g_tooltip.display(g_rootWindow.x + mX, g_rootWindow.y + mY)
+        }
+
         onAtYEndChanged: checkScroll()
 
         Connections {

--- a/src/qml/GamesView.qml
+++ b/src/qml/GamesView.qml
@@ -201,11 +201,11 @@ Item {
         }
 
         onItemClicked: {
-            root.searchChannels(currentItem)
+            root.searchChannels(clickedItem)
         }
 
         onItemRightClicked: {
-            _menu.item = currentItem
+            _menu.item = clickedItem
             _menu.popup()
         }
 

--- a/src/qml/VodsView.qml
+++ b/src/qml/VodsView.qml
@@ -15,6 +15,7 @@
 import QtQuick.Controls 1.4
 import QtQuick 2.5
 import "components"
+import "util.js" as Util
 
 Item{
     anchors.fill: parent
@@ -60,7 +61,7 @@ Item{
         }
     }
 
-    VodGrid {
+    CommonGrid {
         id: vods
         tooltipEnabled: true
 
@@ -89,6 +90,21 @@ Item{
         onItemRightClicked: {
             _menu.item = clickedItem
             _menu.popup()
+        }
+
+        onItemTooltipHover: {
+            g_tooltip.text = ""
+
+            g_tooltip.text += "<b>" + selectedItem.title + "</b><br/>";
+
+            g_tooltip.text += "Playing " + selectedItem.game + "<br/>"
+            if (selectedItem.duration)
+                g_tooltip.text += "Duration " + Util.getTime(selectedItem.duration) + "<br/>"
+
+            g_tooltip.text += selectedItem.views + " views<br/>"
+
+            g_tooltip.img = selectedItem.preview
+            g_tooltip.display(g_rootWindow.x + mX, g_rootWindow.y + mY)
         }
 
         ContextMenu {

--- a/src/qml/VodsView.qml
+++ b/src/qml/VodsView.qml
@@ -83,11 +83,11 @@ Item{
         }
 
         onItemClicked: {
-            playerView.getStreams(selectedChannel, selectedItem)
+            playerView.getStreams(selectedChannel, clickedItem)
         }
 
         onItemRightClicked: {
-            _menu.item = selectedItem
+            _menu.item = clickedItem
             _menu.popup()
         }
 

--- a/src/qml/components/ChannelGrid.qml
+++ b/src/qml/components/ChannelGrid.qml
@@ -39,6 +39,31 @@ CommonGrid {
         _menu.popup()
     }
 
+    onItemTooltipHover: {
+        if (selectedItem.online) {
+            g_tooltip.text = ""
+
+            if (selectedItem.game){
+                g_tooltip.text += "Playing <b>" + selectedItem.game + "</b>"
+            } else if (selectedItem.title){
+                g_tooltip.text += selectedItem.title
+            }
+
+            if (selectedItem.viewers){
+                g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
+                g_tooltip.text += selectedItem.viewers + " viewers"
+            }
+
+            if (selectedItem.info){
+                g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
+                g_tooltip.text += selectedItem.info
+            }
+
+            g_tooltip.img = selectedItem.preview
+            g_tooltip.display(g_rootWindow.x + mX, g_rootWindow.y + mY)
+        }
+    }
+
     ContextMenu {
         id: _menu
 

--- a/src/qml/components/ChannelGrid.qml
+++ b/src/qml/components/ChannelGrid.qml
@@ -22,14 +22,14 @@ CommonGrid {
 
     onItemClicked: {
         if (currentItem.online){
-            playerView.getStreams(currentItem)
+            playerView.getStreams(clickedItem)
         } else {
-            playerView.getChat(currentItem)
+            playerView.getChat(clickedItem)
         }
     }
 
     onItemRightClicked: {
-        _menu.item = currentItem
+        _menu.item = clickedItem
 
         _watchLive.enabled = _menu.item.online
 

--- a/src/qml/components/CommonGrid.qml
+++ b/src/qml/components/CommonGrid.qml
@@ -100,7 +100,8 @@ GridView {
 
         Timer {
             id: tooltipTimer
-            interval: 800
+            // this is longer than the 800ms QML press and hold time so that a press and hold will take precedence
+            interval: 900
             running: false
             repeat: false
             onTriggered: {
@@ -151,6 +152,20 @@ GridView {
                 else if (mouse.button === Qt.RightButton){
                     itemRightClicked(clickedIndex, clickedItem)
                 }
+            }
+        }
+
+        onPressed: {
+            //console.log("pressed");
+            tooltipTimer.restart();
+        }
+
+        onPressAndHold: {
+            //console.log("pressed and held");
+            var clickedIndex = indexAt(mouse.x, mouse.y);
+            if (clickedIndex !== -1){
+                var clickedItem = itemAt(mouse.x, mouse.y);
+                itemRightClicked(clickedIndex, clickedItem);
             }
         }
     }

--- a/src/qml/components/CommonGrid.qml
+++ b/src/qml/components/CommonGrid.qml
@@ -125,9 +125,9 @@ GridView {
         onClicked: {
             // Note that click/press doesn't necessarily set grid's current item so we shouldn't use currentIndex
             // TODO: rework this if something better than a single-point click solution is available for touchscreens
-            var clickedIndex = indexAt(mouse.x, mouse.y);
+            var clickedIndex = indexAt(mouse.x + root.contentX, mouse.y + root.contentY);
             if (clickedIndex !== -1){
-                var clickedItem = itemAt(mouse.x, mouse.y);
+                var clickedItem = itemAt(mouse.x + root.contentX, mouse.y + root.contentY);
                 if (mouse.button === Qt.LeftButton)
                     itemClicked(clickedIndex, clickedItem)
                 else if (mouse.button === Qt.RightButton){
@@ -143,9 +143,9 @@ GridView {
 
         onPressAndHold: {
             //console.log("pressed and held");
-            var clickedIndex = indexAt(mouse.x, mouse.y);
+            var clickedIndex = indexAt(mouse.x + root.contentX, mouse.y + root.contentY);
             if (clickedIndex !== -1){
-                var clickedItem = itemAt(mouse.x, mouse.y);
+                var clickedItem = itemAt(mouse.x + root.contentX, mouse.y + root.contentY);
                 itemRightClicked(clickedIndex, clickedItem);
             }
         }

--- a/src/qml/components/CommonGrid.qml
+++ b/src/qml/components/CommonGrid.qml
@@ -20,8 +20,8 @@ GridView {
     property bool tooltipEnabled: false
     property string title
 
-    signal itemClicked(int index)
-    signal itemRightClicked(int index)
+    signal itemClicked(int index, Item clickedItem)
+    signal itemRightClicked(int index, Item clickedItem)
 
     id: root
 
@@ -145,10 +145,11 @@ GridView {
             // TODO: rework this if something better than a single-point click solution is available for touchscreens
             var clickedIndex = indexAt(mouse.x, mouse.y);
             if (clickedIndex !== -1){
+                var clickedItem = itemAt(mouse.x, mouse.y);
                 if (mouse.button === Qt.LeftButton)
-                    itemClicked(clickedIndex)
+                    itemClicked(clickedIndex, clickedItem)
                 else if (mouse.button === Qt.RightButton){
-                    itemRightClicked(clickedIndex)
+                    itemRightClicked(clickedIndex, clickedItem)
                 }
             }
         }

--- a/src/qml/components/CommonGrid.qml
+++ b/src/qml/components/CommonGrid.qml
@@ -141,11 +141,14 @@ GridView {
         }
 
         onClicked: {
-            if (currentItem){
+            // Note that click/press doesn't necessarily set grid's current item so we shouldn't use currentIndex
+            // TODO: rework this if something better than a single-point click solution is available for touchscreens
+            var clickedIndex = indexAt(mouse.x, mouse.y);
+            if (clickedIndex !== -1){
                 if (mouse.button === Qt.LeftButton)
-                    itemClicked(currentIndex)
+                    itemClicked(clickedIndex)
                 else if (mouse.button === Qt.RightButton){
-                    itemRightClicked(currentIndex)
+                    itemRightClicked(clickedIndex)
                 }
             }
         }

--- a/src/qml/components/CommonGrid.qml
+++ b/src/qml/components/CommonGrid.qml
@@ -22,6 +22,7 @@ GridView {
 
     signal itemClicked(int index, Item clickedItem)
     signal itemRightClicked(int index, Item clickedItem)
+    signal itemTooltipHover(int index, real mX, real mY)
 
     id: root
 
@@ -114,28 +115,8 @@ GridView {
 
                     var index = root.indexAt(mX + root.contentX, mY + root.contentY)
 
-                    if (mArea.containsMouse && selectedItem && selectedItem.online){
-
-                        g_tooltip.text = ""
-
-                        if (selectedItem.game){
-                            g_tooltip.text += "Playing <b>" + selectedItem.game + "</b>"
-                        } else if (selectedItem.title){
-                            g_tooltip.text += selectedItem.title
-                        }
-
-                        if (selectedItem.viewers){
-                            g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
-                            g_tooltip.text += selectedItem.viewers + " viewers"
-                        }
-
-                        if (selectedItem.info){
-                            g_tooltip.text += g_tooltip.text.length > 0 ? "<br/>" : ""
-                            g_tooltip.text += selectedItem.info
-                        }
-
-                        g_tooltip.img = selectedItem.preview
-                        g_tooltip.display(g_rootWindow.x + mX, g_rootWindow.y + mY)
+                    if (mArea.containsMouse && selectedItem){
+                        root.itemTooltipHover(index, mX, mY);
                     }
                 }
             }

--- a/src/qml/components/VodGrid.qml
+++ b/src/qml/components/VodGrid.qml
@@ -16,14 +16,16 @@ import QtQuick 2.5
 
 import "../util.js" as Util
 
+// Could this not be using CommonGrid?
+
 //ChannelList.qml
 GridView {
     property variant selectedItem
     property bool tooltipEnabled: false
     property string title
 
-    signal itemClicked(int index)
-    signal itemRightClicked(int index)
+    signal itemClicked(int index, Item clickedItem)
+    signal itemRightClicked(int index, Item clickedItem)
 
     id: root
 
@@ -135,11 +137,15 @@ GridView {
         }
 
         onClicked: {
-            if (currentItem){
+            // Note that click/press doesn't necessarily set grid's current item so we shouldn't use currentIndex
+            // TODO: rework this if something better than a single-point click solution is available for touchscreens
+            var clickedIndex = indexAt(mouse.x, mouse.y);
+            if (clickedIndex !== -1){
+                var clickedItem = itemAt(mouse.x, mouse.y);
                 if (mouse.button === Qt.LeftButton)
-                    itemClicked(currentIndex)
+                    itemClicked(clickedIndex, clickedItem);
                 else if (mouse.button === Qt.RightButton){
-                    itemRightClicked(currentIndex)
+                    itemRightClicked(clickedIndex, clickedItem);
                 }
             }
         }

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -40,7 +40,6 @@
         <file>VodsView.qml</file>
         <file>components/Video.qml</file>
         <file>components/SeekBar.qml</file>
-        <file>components/VodGrid.qml</file>
         <file>util.js</file>
         <file>WebView.qml</file>
         <file>components/GradientBottom.qml</file>


### PR DESCRIPTION
Various changes to grids to support touch screen use (tested with a Windows 10 tablet)
- Fixed grids (e.g. channels, games, vods) click handlers to determine the clicked item with click coordinates as `selectedItem` does not get set when click signals fire due to touch events.
- Added press and hold handler to open context menu; increased the tooltip timeout slightly and added a tooltip timer reset on press so tooltips don't get ahead of the press and hold.
- Refactored `VodView` to use `ChannelGrid` rather than its own `VodGrid` and refactored tooltip implementations to support this. (Tooltips still require a mouse.)