### PR TITLE
side margins for chat

### DIFF
--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -80,6 +80,10 @@ Item {
         anchors {
             left: parent.left
             right: parent.right
+            margins: {
+                leftMargin: dp(2)
+                rightMargin: dp(2)
+            }
         }
 
         visible: showSystemMessageLine
@@ -98,6 +102,10 @@ Item {
           top: _systemMessageLine.bottom
           left: parent.left
           right: parent.right
+          margins: {
+              leftMargin: dp(2)
+              rightMargin: dp(2)
+          }
       }
 
       vAlign: vAlignCenter


### PR DESCRIPTION
At risk of pushing a layout nitpick, the lack of space between chat and the video bugs me (especially now  that there are rectangular badges at the left side of chat that are completely flush with the video)