### PR TITLE
VOD chat replay

### DIFF
--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -126,6 +126,8 @@ ChannelManager::ChannelManager(NetworkManager *netman) : netman(netman), badgeIm
     connect(netman, SIGNAL(getChannelBadgeBetaUrlsOperationFinished(const int, const QMap<QString, QMap<QString, QMap<QString, QString>>>)), this, SLOT(innerChannelBadgeBetaUrlsLoaded(const int, const QMap<QString, QMap<QString, QMap<QString, QString>>>)));
     connect(netman, SIGNAL(getGlobalBadgeBetaUrlsOperationFinished(const QMap<QString, QMap<QString, QMap<QString, QString>>>)), this, SLOT(innerGlobalBadgeBetaUrlsLoaded(const QMap<QString, QMap<QString, QMap<QString, QString>>>)));
     connect(netman, SIGNAL(favouritesReplyFinished(const QList<Channel*>&, const quint32)), this, SLOT(addFollowedResults(const QList<Channel*>&, const quint32)));
+    connect(netman, SIGNAL(vodStartGetOperationFinished(double)), this, SIGNAL(vodStartGetOperationFinished(double)));
+    connect(netman, SIGNAL(vodChatPieceGetOperationFinished(QList<ReplayChatMessage>)), this, SIGNAL(vodChatPieceGetOperationFinished(QList<ReplayChatMessage>)));
 
     connect(netman, SIGNAL(networkAccessChanged(bool)), this, SLOT(onNetworkAccessChanged(bool)));
     load();
@@ -729,6 +731,14 @@ bool ChannelManager::loadChannelBetaBadgeUrls(int channel) {
     }
 
     return out;
+}
+
+void ChannelManager::getVodStartTime(quint64 vodId) {
+    netman->getVodStartTime(vodId);
+}
+
+void ChannelManager::getVodChatPiece(quint64 vodId, quint64 offset) {
+    netman->getVodChatPiece(vodId, offset);
 }
 
 void ChannelManager::onEmoteSetsUpdated(const QMap<int, QMap<int, QString>> updatedEmoteSets)

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -147,6 +147,9 @@ public:
     Q_INVOKABLE bool loadChannelBadgeUrls(const QString channel);
     Q_INVOKABLE bool loadChannelBetaBadgeUrls(int channel);
 
+    Q_INVOKABLE void getVodStartTime(quint64 vodId);
+    Q_INVOKABLE void getVodChatPiece(quint64 vodId, quint64 offset);
+
     void setSwapChat(bool value);
     bool getSwapChat();
 
@@ -211,6 +214,9 @@ signals:
     void emoteSetsLoaded(QVariantMap emoteSets);
     void channelBadgeUrlsLoaded(const QString &channel, QVariantMap badgeUrls);
     void channelBadgeBetaUrlsLoaded(const QString &channel, QVariantMap badgeSetData);
+
+    void vodStartGetOperationFinished(double);
+    void vodChatPieceGetOperationFinished(QList<ReplayChatMessage>);
 
 public slots:
     void checkFavourites();

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -92,9 +92,6 @@ void IrcChat::hookupChannelProviders(ChannelManager * cman) {
     }
 }
 
-void channelBadgeUrlsLoaded(const QString &channel, QVariantMap badgeUrls);
-void channelBadgeBetaUrlsLoaded(const QString &channel, QVariantMap badgeSetData);
-
 IrcChat::~IrcChat() {
     disconnect();
 }

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -72,6 +72,9 @@ public:
     Q_PROPERTY(QList<int> emoteSetIDs READ emoteSetIDs NOTIFY emoteSetIDsChanged)
 
     Q_INVOKABLE void join(const QString channel, const QString channelId);
+    Q_INVOKABLE void replay(const QString channel, const QString channelId, const quint64 vodId, double vodStartEpochTime, double playbackOffset);
+    Q_INVOKABLE void replaySeek(double newOffset);
+    Q_INVOKABLE void replayUpdate(double newOffset);
     Q_INVOKABLE void leave();
     Q_INVOKABLE void disconnect();
     Q_INVOKABLE void reopenSocket();
@@ -124,10 +127,13 @@ private slots:
     void receive();
     void processError(QAbstractSocket::SocketError socketError);
     void handleDownloadComplete();
+    void handleVodStartTime(double);
+    void handleDownloadedReplayChat(QList<ReplayChatMessage>);
 
 private:
     URLFormatImageProvider _emoteProvider;
     BadgeImageProvider * _badgeProvider;
+    ChannelManager * _cman;
     
     QList<ChatMessage> msgQueue;
 
@@ -164,6 +170,22 @@ private:
     QMap<QString, bool> userChannelMod;
     QMap<QString, bool> userChannelSubscriber;
     bool allDownloadsComplete();
+
+    bool replayChatRequestInProgress;
+    
+    bool replayChatMessageTimestampOffsetCalibrated;
+    double replayChatMessageTimestampOffset;
+    double replayChatVodStartTime;
+    double replayChatFirstChunkTime;
+    double replayChatCurrentSeekOffset;
+    double replayChatCurrentTime; // the position that playback is currently at in chat
+    double nextChatChunkTimestamp;
+    
+    quint64 replayVodId;
+    QList<ReplayChatMessage> replayChatMessagesPending;
+
+    void replayChatMessage(const ReplayChatMessage &);
+    void replayUpdateCommon();
 };
 
 #endif // IRCCHAT_H

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -173,8 +173,6 @@ private:
 
     bool replayChatRequestInProgress;
     
-    bool replayChatMessageTimestampOffsetCalibrated;
-    double replayChatMessageTimestampOffset;
     double replayChatVodStartTime;
     double replayChatFirstChunkTime;
     double replayChatCurrentSeekOffset;

--- a/src/network/networkmanager.h
+++ b/src/network/networkmanager.h
@@ -33,6 +33,8 @@
 #include "../model/game.h"
 #include "../model/vod.h"
 
+#include "replaychat.h"
+
 #define ONLY_BROADCASTS true
 #define USE_HLS true
 #define FOLLOWED_FETCH_LIMIT 25
@@ -75,6 +77,9 @@ public:
     void getChannelBadgeUrlsBeta(const int channelID);
     void getGlobalBadgesUrlsBeta();
 
+    Q_INVOKABLE void getVodStartTime(quint64 vodId);
+    Q_INVOKABLE void getVodChatPiece(quint64 vodId, quint64 offset);
+
     QNetworkAccessManager *getManager() const;
 
     //TODO: move to new class if more operations need to be added
@@ -106,6 +111,9 @@ signals:
     void getChannelBadgeBetaUrlsOperationFinished(const int, const QMap<QString, QMap<QString, QMap<QString, QString>>>);
     void getGlobalBadgeBetaUrlsOperationFinished(const QMap<QString, QMap<QString, QMap<QString, QString>>>);
 
+    void vodStartGetOperationFinished(double);
+    void vodChatPieceGetOperationFinished(QList<ReplayChatMessage>);
+
     void networkAccessChanged(bool up);
 
 private slots:
@@ -125,6 +133,8 @@ private slots:
     void favouritesReply();
     void editUserFavouritesReply();
     void streamReply();
+    void vodStartReply();
+    void vodChatPieceReply();
 
     //Oauth slots
     void userReply();
@@ -137,6 +147,16 @@ private:
     QNetworkAccessManager *operation;
     bool connectionOK;
     QTimer offlinePoller;
+
+    const int REPLAY_CHAT_DEDUPE_SWAP_ITERATIONS = 5;
+    int replayChatPartNum = 0;
+
+    QSet<QString> * curChatReplayDedupeBatch;
+    QSet<QString> * prevChatReplayDedupeBatch;
+
+    void initReplayChat();
+    void teardownReplayChat();
+    void filterReplayChat(QList<ReplayChatMessage> & replayChat);
 };
 
 #endif // NETWORKMANAGER_H

--- a/src/network/replaychat.h
+++ b/src/network/replaychat.h
@@ -1,0 +1,32 @@
+/*
+* Copyright © 2015-2016 Antti Lamminsalo
+*
+* This file is part of Orion.
+*
+* Orion is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* You should have received a copy of the GNU General Public License
+* along with Orion.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef REPLAYCHAT_H
+#define REPLAYCHAT_H
+
+struct ReplayChatMessage {
+    QString id;
+    QString from;
+    bool deleted;
+    QString message;
+    QString room;
+    QString command;
+    double timestamp;
+    double videoOffset;
+    QVariantMap tags;
+    QMap<int, QPair<int, int>> emotePositionsMap; // first -> (last, emoteId)
+    QList<int> emoteList;
+};
+
+#endif

--- a/src/network/urls.h
+++ b/src/network/urls.h
@@ -18,6 +18,7 @@
 #define KRAKEN_API "https://api.twitch.tv/kraken"
 #define TWITCH_API "https://api.twitch.tv/api"
 #define TWITCH_API_BASE "https://api.twitch.tv/kraken/base"
+#define TWITCH_RECHAT_API "https://rechat.twitch.tv/rechat-messages"
 //#define TWITCH_EMOTES "http://static-cdn.jtvnw.net/emoticons/v1/"
 #define CLIENT_ID "0dpzlnp1w2bjlim3ldp0u96o4dq2gm"
 

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -200,7 +200,23 @@ Item {
         _favIcon.update()
         _label.visible = false
         setWatchingTitle()
-        chatview.joinChannel(currentChannel.name, currentChannel._id)
+
+        if (isVod) {
+            var startEpochTime = (new Date(vod.createdAt)).getTime() / 1000.0;
+
+            console.log("typeof vod._id is", typeof(vod._id))
+
+            if (vod._id.charAt(0) !== "v") {
+                console.log("unknown vod id format in", vod._id);
+            } else {
+                var vodIdNum = parseInt(vod._id.substring(1));
+                console.log("replaying chat for vod", vodIdNum, "starting at", startEpochTime);
+                chatview.replayChat(currentChannel.name, currentChannel._id, vodIdNum, startEpochTime);
+            }
+        } else {
+            chatview.joinChannel(currentChannel.name, currentChannel._id);
+        }
+
         pollTimer.restart()
 
         requestSelectionChange(5)
@@ -239,6 +255,7 @@ Item {
     function seekTo(position) {
         console.log("Seeking to", position, duration)
         if (isVod){
+            chatview.replaySeek(position)
             renderer.seekTo(position)
         }
     }
@@ -275,6 +292,7 @@ Item {
         }
 
         onPositionChanged: {
+            chatview.replayUpdate(renderer.position);
             seekBar.setPosition(renderer.position, duration)
         }
 

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -183,6 +183,8 @@ Item {
 
                 seekBar.setPosition(0, duration)
             }
+        } else {
+            isVod = false;
         }
 
         currentChannel = {

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -33,6 +33,7 @@ Item {
     property var channel: undefined
     property var channelId: undefined
     property var singleShot: undefined
+    property var replayMode: false
 
     Component.onCompleted: {
         chat.hookupChannelProviders(g_cman)
@@ -65,9 +66,40 @@ Item {
         chat.join(channelName, channelId)
         root.channel = channelName
         root.channelId = channelId
+        root.replayMode = false;
         messageReceived("notice", null, "", false, false, false, [], true, "Joined channel #" + channelName)
         g_cman.loadChannelBadgeUrls(channelName);
         g_cman.loadChannelBetaBadgeUrls(channelId);
+    }
+
+    function replayChat(channelName, channelId, vodId, startEpochTime) {
+        chat.replay(channelName, channelId, vodId, startEpochTime, 0)
+        root.channel = channelName
+        root.channelId = channelId
+        root.replayMode = true
+        messageReceived("notice", null, "", false, false, false, [], true, "Starting chat replay #" + channelName + " v" + vodId)
+        g_cman.loadChannelBadgeUrls(channelName);
+        g_cman.loadChannelBetaBadgeUrls(channelId);
+    }
+
+    function durationStr(duration) {
+        var hours = Math.floor(duration / 3600);
+        var mins = Math.floor((duration % 3600) / 60);
+        var secs = Math.floor(duration % 60);
+        var out = mins.toString() + ":" + (secs < 10 ? "0" : "") + secs.toString();
+        if (hours > 0) {
+            out = hours.toString() + ":" + (mins < 10 ? "0" : "") + out;
+        }
+        return out;
+    }
+
+    function replaySeek(newOffset) {
+        messageReceived("notice", null, "", false, false, false, [], true, "Seeking to " + durationStr(newOffset));
+        chat.replaySeek(newOffset);
+    }
+
+    function replayUpdate(newOffset) {
+        chat.replayUpdate(newOffset);
     }
 
     function leaveChannel() {

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -53,7 +53,7 @@ Item {
     }
 
     function joinChannel(channel, channelId) {
-        if (channel != chat.channel) {
+        if (channel !== chat.channel || chat.replayMode) {
             chatModel.clear()
             chat.joinChannel(channel, channelId)
         }
@@ -62,6 +62,20 @@ Item {
     function leaveChannel() {
         chatModel.clear()
         chat.leaveChannel()
+    }
+
+    function replayChat(channelName, channelId, vodId, startEpochTime) {
+        chatModel.clear()
+        chat.leaveChannel()
+        chat.replayChat(channelName, channelId, vodId, startEpochTime);
+    }
+
+    function replaySeek(newOffset) {
+        chat.replaySeek(newOffset);
+    }
+
+    function replayUpdate(newOffset) {
+        chat.replayUpdate(newOffset);
     }
 
     function sendMessage() {
@@ -273,7 +287,7 @@ Item {
             right: parent.right
         }
 
-        visible: !chat.isAnonymous
+        visible: !chat.isAnonymous && !chat.replayMode
 
         Rectangle {
             anchors.fill: parent

--- a/src/util/jsonparser.h
+++ b/src/util/jsonparser.h
@@ -24,6 +24,7 @@
 #include "../model/channel.h"
 #include "../model/game.h"
 #include "../model/vod.h"
+#include "../network/replaychat.h"
 
 /**
  * @brief The JsonParser class
@@ -52,6 +53,7 @@ public:
     static QMap<int, QMap<int, QString>> parseEmoteSets(const QByteArray&);
     static QMap<QString, QMap<QString, QString>> parseChannelBadgeUrls(const QByteArray &data);
     static QMap<QString, QMap<QString, QMap<QString, QString>>> parseBadgeUrlsBetaFormat(const QByteArray &data);
+    static QList<ReplayChatMessage> parseVodChatPiece(const QByteArray &data);
 };
 
 #endif // JSONPARSER_H


### PR DESCRIPTION
When playing a VOD, replay chat that happened during the original broadcast instead of joining the live chat channel.

This is a hack, in that it uses the undocumented chat replay API that Twitch web UI uses, and it scrapes the VOD's chat replay start time from an error message (it seems that the chat-replay chunk requests need to be aligned to 30s intervals based on that start time to not miss messages, and the chat replay start value doesn't correspond to the VOD start time and doesn't seem to be available elsewhere).  Messages are deduplicated by id in a 150-300 second window in case the responses overlap, although since I switched to the start-aligned 30s intervals I don't see duplicates in practice.

FYI this branch contains the `mpv_time_offset_workaround` branch.