### PR TITLE
load and play fixes

### DIFF
--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -91,7 +91,7 @@ Item {
         onNetworkAccessChanged: {
             if (up && currentChannel && !renderer.status !== "PAUSED") {
                 //console.log("Network up. Resuming playback...")
-                loadAndPlay()
+                loadAndPlay(currentQualityName)
             }
         }
 
@@ -100,7 +100,7 @@ Item {
             if (channelName === currentChannel.name) {
                 if (online && !root.streamOnline) {
                     console.log("Stream back online, resuming playback")
-                    loadAndPlay()
+                    loadAndPlay(currentQualityName)
                 }
                 root.streamOnline = online
             }
@@ -245,7 +245,7 @@ Item {
 
     function reloadStream() {
         renderer.stop()
-        loadAndPlay()
+        loadAndPlay(currentQualityName)
     }
 
     Connections {


### PR DESCRIPTION
These must have been missed when `loadAndPlay` was reworked earlier.
Fixed
- reload stream button
- resume when network comes back
- resume when channel goes online

