### PR TITLE
don't join live chat when the network recovers from an issue during chat replay

### DIFF
--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -40,7 +40,8 @@ IrcChat::IrcChat(QObject *parent) :
     QObject(parent),
     _emoteProvider(IMAGE_PROVIDER_EMOTE, EMOTICONS_URL_FORMAT, ".png", "emotes"),
     _badgeProvider(nullptr),
-    _cman(nullptr)
+    _cman(nullptr),
+    replayMode(false)
     {
 
     logged_in = false;
@@ -98,6 +99,7 @@ IrcChat::~IrcChat() {
 }
 
 void IrcChat::join(const QString channel, const QString channelId) {
+    replayMode = false;
 
     if (inRoom())
         leave();
@@ -122,6 +124,8 @@ void IrcChat::join(const QString channel, const QString channelId) {
 }
 
 void IrcChat::replay(const QString channel, const QString channelId, const quint64 vodId, double vodStartEpochTime, double playbackOffset) {
+    replayMode = true;
+
     if (inRoom())
         leave();
 
@@ -534,7 +538,7 @@ void IrcChat::login()
     logged_in = true;
 
     //Join room automatically, if given
-    if (!room.isEmpty())
+    if (!room.isEmpty() && !replayMode)
         join(room, roomChannelId);
 }
 

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -159,6 +159,7 @@ private:
     QTcpSocket *sock;
     QString room;
     QString roomChannelId;
+    bool replayMode;
     // map of channel name -> list of pairs (badge name, badge version)
     QMap<QString, QList<QPair<QString, QString>>> badgesByChannel;
     bool logged_in;

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -132,9 +132,13 @@ Item {
 
         onConnectedChanged: {
             if (connected) {
-                console.log("Connected to chat")
                 if (root.channel) {
-                    joinChannel(root.channel, root.channelId)
+                    if (root.replayMode) {
+                        console.log("Reconnected; chat replay may resume")
+                    } else {
+                        console.log("Connected to chat")
+                        joinChannel(root.channel, root.channelId)
+                    }
                 }
             } else {
                 console.log("Disconnected from chat")


### PR DESCRIPTION
If we are in a channel, and there is a network issue and it recovers, don't join the live chat channel if there is a VOD chat replay in progress.

Occasionally while watching a VOD, I've seen a transient network error followed by chat switching back to the live chat channel. I haven't reproduced one of these in a debugger, but I've tested this fix by completely interrupting and restoring network connectivity.