### PR TITLE
receive and send whispers from the chat view

### DIFF
--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -464,11 +464,9 @@ bool IrcChat::addBadges(QVariantList &badges, QString channel) {
 
 void IrcChat::sendMessage(const QString &msg, const QVariantMap &relevantEmotes) {
     if (inRoom() && connected()) {
-        if (sock) {
-            sock->write(("PRIVMSG #" + room + " :" + msg + "\r\n").toStdString().c_str());
-        }
-
 		bool isAction = false;
+        bool isWhisper = false;
+        QString recipient = "";
 		QVariantList message;
 		const QString ME_PREFIX = "/me ";
 		QString displayMessage = msg;
@@ -476,6 +474,30 @@ void IrcChat::sendMessage(const QString &msg, const QVariantMap &relevantEmotes)
 			isAction = true;
 			displayMessage = displayMessage.mid(ME_PREFIX.length());
 		}
+        const QString MSG_PREFIX = "/msg ";
+        if (displayMessage.startsWith(MSG_PREFIX)) {
+            isWhisper = true;
+            QString rest = displayMessage.mid(MSG_PREFIX.length());
+            int spacePos = rest.indexOf(' ');
+            if (spacePos == -1 || spacePos == rest.length() - 1) {
+                emit noticeReceived("Ignoring /msg with empty message");
+                return;
+            }
+            recipient = rest.left(spacePos);
+            displayMessage = rest.mid(spacePos + 1);
+        }
+
+        if (sock) {
+            QString ircCmd;
+            if (isWhisper) {
+                ircCmd = "PRIVMSG #" + room + " :/w " + recipient + " " + displayMessage + "\r\n";
+            }
+            else {
+                ircCmd = "PRIVMSG #" + room + " :" + msg + "\r\n";
+            }
+            sock->write(ircCmd.toStdString().c_str());
+        }
+
 		addWordSplit(displayMessage, ' ', message);
         message = substituteEmotesInMessage(message, relevantEmotes);
 
@@ -523,7 +545,9 @@ void IrcChat::sendMessage(const QString &msg, const QVariantMap &relevantEmotes)
             displayName = userGlobalDisplayName;
         }
 
-        disposeOfMessage({ displayName, message, color, subscriber, turbo, mod, isAction, userBadges, false, "" });
+        bool isChannelMessage = isWhisper;
+        QString systemMessage = isWhisper ? ("Whispered to " + recipient + ":") : "";
+        disposeOfMessage({ displayName, message, color, subscriber, turbo, mod, isAction, userBadges, isChannelMessage, systemMessage, false });
     }
 }
 
@@ -604,7 +628,7 @@ bool IrcChat::allDownloadsComplete() {
 
 void IrcChat::disposeOfMessage(ChatMessage m) {
     if (allDownloadsComplete()) {
-        emit messageReceived(m.name, m.messageList, m.color, m.subscriber, m.turbo, m.mod, m.isAction, m.badges, m.isChannelNotice, m.systemMessage);
+        emit messageReceived(m.name, m.messageList, m.color, m.subscriber, m.turbo, m.mod, m.isAction, m.badges, m.isChannelNotice, m.systemMessage, m.isWhisper);
     }
     else {
         // queue message to be shown when downloads are complete
@@ -738,6 +762,7 @@ void IrcChat::parseMessageCommand(const QString cmd, const QString cmdKeyword, C
 
     chatMessage.isAction = false;
     chatMessage.isChannelNotice = false;
+    chatMessage.isWhisper = false;
 
     foreach(const QString & tagStr, commandParse.tags) {
         Tag tag(tagStr);
@@ -876,9 +901,35 @@ void IrcChat::parseCommand(QString cmd) {
         disposeOfMessage(parse.chatMessage);
         return;
     }
+    if (cmd.contains("WHISPER")) {
+        // Structure of message: 
+        // @badges=;color=;display-name=TWitch_UserName;emotes=;message-id=2;thread-id=56781234_142000000;turbo=0;user-id=123456789;user-type= :twitch_username!twitch_username@twitch_username.tmi.twitch.tv WHISPER other_twitch_user :hi
+        CommandParse parse;
+
+        parseMessageCommand(cmd, "WHISPER", parse);
+
+        if (parse.wrongChannel) {
+            return;
+        }
+
+        parse.chatMessage.isChannelNotice = true;
+        parse.chatMessage.isWhisper = true;
+
+        parse.chatMessage.systemMessage = QString("Whisper from");
+
+        createEmoteMessageList(parseEmotesTag(parse.emotesStr), parse.chatMessage.messageList, parse.message);
+
+        //qDebug() << "messageList " << messageList;
+
+        qDebug() << "whisper isWhisper" << parse.chatMessage.isWhisper;
+        disposeOfMessage(parse.chatMessage);
+        return;
+
+    }
     if(cmd.contains("NOTICE")) {
         QString text = cmd.remove(0, cmd.indexOf(':', cmd.indexOf("NOTICE")) + 1);
         emit noticeReceived(text);
+        return;
     }
     if(cmd.contains("GLOBALUSERSTATE")) {
 		// Structure of message: @badges=turbo/1;color=#4100CC;display-name=user_name;emote-sets=0,1,22,345;user-id=12345678;user-type= :tmi.twitch.tv GLOBALUSERSTATE
@@ -962,7 +1013,7 @@ void IrcChat::parseCommand(QString cmd) {
         }
         return;
     }
-    //qDebug() << "Unrecognized chat command:" << cmd;
+    qDebug() << "Unrecognized chat command:" << cmd;
 }
 
 QString IrcChat::getParamValue(QString params, QString param) {
@@ -982,7 +1033,7 @@ void IrcChat::handleDownloadComplete() {
         //qDebug() << "Download queue complete; posting pending messages";
         while (!msgQueue.empty()) {
             ChatMessage tmpMsg = msgQueue.first();
-            emit messageReceived(tmpMsg.name, tmpMsg.messageList, tmpMsg.color, tmpMsg.subscriber, tmpMsg.turbo, tmpMsg.mod, tmpMsg.isAction, tmpMsg.badges, tmpMsg.isChannelNotice, tmpMsg.systemMessage);
+            emit messageReceived(tmpMsg.name, tmpMsg.messageList, tmpMsg.color, tmpMsg.subscriber, tmpMsg.turbo, tmpMsg.mod, tmpMsg.isAction, tmpMsg.badges, tmpMsg.isChannelNotice, tmpMsg.systemMessage, tmpMsg.isWhisper);
             msgQueue.pop_front();
         }
     }

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -50,6 +50,7 @@ struct ChatMessage {
     QVariantList badges;
     bool isChannelNotice;
     QString systemMessage;
+    bool isWhisper;
 };
 
 // Backend for chat
@@ -106,7 +107,7 @@ signals:
     void connectedChanged();
     void emoteSetIDsChanged();
     void anonymousChanged();
-    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool mod, bool isAction, QVariantList badges, bool isChannelNotice, QString systemMessage);
+    void messageReceived(QString user, QVariantList message, QString chatColor, bool subscriber, bool turbo, bool mod, bool isAction, QVariantList badges, bool isChannelNotice, QString systemMessage, bool isWhisper);
     void noticeReceived(QString message);
     void myBadgesForChannel(QString channel, QList<QPair<QString, QString>> badges);
 

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -20,7 +20,7 @@ import aldrog.twitchtube.ircchat 1.0
 Item {
     id: root
 
-    signal messageReceived(string user, variant message, string chatColor, bool subscriber, bool turbo, bool isAction, var badges, bool isChannelNotice, string systemMessage)
+    signal messageReceived(string user, variant message, string chatColor, bool subscriber, bool turbo, bool isAction, var badges, bool isChannelNotice, string systemMessage, bool isWhisper)
     signal setEmotePath(string value)
     signal notify(string message)
     signal clear()
@@ -70,7 +70,7 @@ Item {
             chat.replayStop();
         }
         root.replayMode = false;
-        messageReceived("notice", null, "", false, false, false, [], true, "Joined channel #" + channelName)
+        messageReceived("notice", null, "", false, false, false, [], true, "Joined channel #" + channelName, false)
         g_cman.loadChannelBadgeUrls(channelName);
         g_cman.loadChannelBetaBadgeUrls(channelId);
     }
@@ -80,7 +80,7 @@ Item {
         root.channel = channelName
         root.channelId = channelId
         root.replayMode = true
-        messageReceived("notice", null, "", false, false, false, [], true, "Starting chat replay #" + channelName + " v" + vodId)
+        messageReceived("notice", null, "", false, false, false, [], true, "Starting chat replay #" + channelName + " v" + vodId, false)
         g_cman.loadChannelBadgeUrls(channelName);
         g_cman.loadChannelBetaBadgeUrls(channelId);
     }
@@ -97,7 +97,7 @@ Item {
     }
 
     function replaySeek(newOffset) {
-        messageReceived("notice", null, "", false, false, false, [], true, "Seeking to " + durationStr(newOffset));
+        messageReceived("notice", null, "", false, false, false, [], true, "Seeking to " + durationStr(newOffset), false);
         chat.replaySeek(newOffset);
     }
 
@@ -143,12 +143,12 @@ Item {
 
         onMessageReceived: {
             root.setEmotePath(emoteDirPath)
-            root.messageReceived(user, message, chatColor, subscriber, turbo, isAction, badges, isChannelNotice, systemMessage)
+            root.messageReceived(user, message, chatColor, subscriber, turbo, isAction, badges, isChannelNotice, systemMessage, isWhisper)
         }
 
         onNoticeReceived: {
             console.log("Notification received", message);
-            root.messageReceived("channel", [], null, null, false, false, {}, true, message)
+            root.messageReceived("channel", [], null, null, false, false, {}, true, message, false)
         }
 
         onEmoteSetIDsChanged: {

--- a/src/qml/irc/ChatMessage.qml
+++ b/src/qml/irc/ChatMessage.qml
@@ -26,6 +26,7 @@ Item {
     property string jsonBadgeEntries
     property string emoteDirPath
     property bool isChannelNotice
+    property bool isWhisper
     property string systemMessage
     property int fontSize: Styles.titleFont.smaller
     property var pmsg: JSON.parse(msg)
@@ -252,13 +253,18 @@ Item {
     {
         if (link.substr(0,5) === "user:")
         {
-            var value = "@"+link.replace('user:',"")+', '
-            if (_input.text === "")
-            {
-                _input.text = value
-            }
-            else {
-                _input.text = _input.text + ' '+ value
+            var clickedUser = link.replace('user:',"");
+            if (isWhisper) {
+                _input.text = "/msg " + clickedUser + " " + _input.text;
+            } else {
+                var value = "@" + clickedUser + ', ';
+                if (_input.text === "")
+                {
+                    _input.text = value
+                }
+                else {
+                    _input.text = _input.text + ' '+ value
+                }
             }
 
         }

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -179,6 +179,7 @@ Item {
             emoteDirPath: chat.emoteDirPath
             isChannelNotice: model.isChannelNotice
             systemMessage: model.systemMessage
+            isWhisper: model.isWhisper
             highlightOpacity: root._opacity
 
             anchors {
@@ -766,7 +767,7 @@ Item {
 
             var jsonBadgeEntries = JSON.stringify(badgeEntries);
 
-            chatModel.append({"user": user, "message": serializedMessage, "isAction": isAction, "jsonBadgeEntries": jsonBadgeEntries, "isChannelNotice": isChannelNotice, "systemMessage": systemMessage})
+            chatModel.append({"user": user, "message": serializedMessage, "isAction": isAction, "jsonBadgeEntries": jsonBadgeEntries, "isChannelNotice": isChannelNotice, "systemMessage": systemMessage, "isWhisper": isWhisper})
             list.scrollbuf = 6
         }
 


### PR DESCRIPTION
This adds support for receiving and sending (with `/msg`) private messages (whispers) from chat view.
Re https://github.com/alamminsalo/orion/issues/108. No notification support for whispers yet.