### PR TITLE
Bulk emote download performance tweaks

### DIFF
--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -36,7 +36,7 @@ QString BadgeImageProvider::getCanonicalKey(QString key) {
     if (splitPos != -1) {
         const QString badge = key.left(splitPos);
         const QString version = key.mid(splitPos + 1);
-        qDebug() << "badge hunt: channel name" << _channelName << "channel id" << _channelId << "badge" << badge << "version" << version;
+        //qDebug() << "badge hunt: channel name" << _channelName << "channel id" << _channelId << "badge" << badge << "version" << version;
 
         if (_channelManager->getChannelBadgeBetaUrl(_channelId, badge, version, betaImageFormat, url)) {
             return QList<QString>({ _channelId, badge, version, betaImageFormat }).join("-");

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -26,7 +26,7 @@
 const int ImageProvider::MSEC_PER_DOWNLOAD = 16; // ~ 256kbit/sec for 2k images
 
 ImageProvider::ImageProvider(const QString imageProviderName, const QString extension, const QString cacheDirName) : 
-    _imageProviderName(imageProviderName), _extension(extension), _bulkDownloadStarting(false) {
+    _imageProviderName(imageProviderName), _extension(extension) {
 
     activeDownloadCount = 0;
 
@@ -111,21 +111,15 @@ void ImageProvider::bulkDownloadStep() {
         }
     }
 
-    _bulkDownloadStarting = false;
     emit bulkDownloadComplete();
 }
 
-bool ImageProvider::bulkDownload(const QList<QString> & keys) {
-    Q_ASSERT(!_bulkDownloadStarting);
-    _bulkDownloadStarting = true;
-
+void ImageProvider::bulkDownload(const QList<QString> & keys) {
     _curBulkDownloadKeys = keys;
 
     _bulkDownloadPos = keys.constBegin();
 
     bulkDownloadStep();
-
-    return _bulkDownloadStarting || activeDownloadCount > 0;
 }
 
 

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -26,7 +26,7 @@
 const int ImageProvider::MSEC_PER_DOWNLOAD = 16; // ~ 256kbit/sec for 2k images
 
 ImageProvider::ImageProvider(const QString imageProviderName, const QString extension, const QString cacheDirName) : 
-    _imageProviderName(imageProviderName), _extension(extension), _bulkDownloadStarting(false), _downloadCompletePending(false) {
+    _imageProviderName(imageProviderName), _extension(extension), _bulkDownloadStarting(false) {
 
     activeDownloadCount = 0;
 
@@ -112,10 +112,7 @@ void ImageProvider::bulkDownloadStep() {
     }
 
     _bulkDownloadStarting = false;
-    if (_downloadCompletePending) {
-        _downloadCompletePending = false;
-        emit downloadComplete();
-    }
+    emit bulkDownloadComplete();
 }
 
 bool ImageProvider::bulkDownload(const QList<QString> & keys) {
@@ -153,12 +150,7 @@ void ImageProvider::individualDownloadComplete(QString filename, bool hadError) 
     currentlyDownloading.remove(emoteKey);
 
     if (activeDownloadCount == 0) {
-        if (_bulkDownloadStarting) {
-            _downloadCompletePending = true;
-        }
-        else {
-            emit downloadComplete();
-        }
+        emit downloadComplete();
     }
 }
 

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -95,20 +95,18 @@ bool ImageProvider::bulkDownload(const QList<QString> & keys) {
     Q_ASSERT(!_bulkDownloadStarting);
     _bulkDownloadStarting = true;
     const int MSEC_PER_DOWNLOAD = 16; // ~ 256kbit/sec for 2k images
-    qint64 startTime = QDateTime::currentMSecsSinceEpoch();
-    qint64 nextDownloadTime = startTime;
     bool waitForDownloadComplete = false;
     for (const auto & key : keys) {
+        qint64 curTime = QDateTime::currentMSecsSinceEpoch();
+        qint64 nextDownloadTime = curTime + MSEC_PER_DOWNLOAD;
         if (makeAvailable(key)) {
             waitForDownloadComplete = true;
-            nextDownloadTime += MSEC_PER_DOWNLOAD;
             do {
                 qApp->processEvents();
-                qint64 curTime = QDateTime::currentMSecsSinceEpoch();
+                curTime = QDateTime::currentMSecsSinceEpoch();
                 if (curTime >= nextDownloadTime) break;
-                if (qAbs(curTime - startTime) > 600000) {
+                if (curTime < nextDownloadTime - 100) {
                     // assume clock jump
-                    startTime = nextDownloadTime = curTime;
                     break;
                 }
             } while (true);

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -57,7 +57,7 @@ bool ImageProvider::makeAvailable(QString key) {
 
 bool ImageProvider::download(QString key) {
     if (_imageTable.contains(key)) {
-        qDebug() << "already in the table";
+        //qDebug() << "already in the table";
         return false;
     }
 

--- a/src/model/imageprovider.h
+++ b/src/model/imageprovider.h
@@ -85,7 +85,7 @@ signals:
     void bulkDownloadComplete();
 
 public slots:
-    bool bulkDownload(const QList<QString> & keys);
+    void bulkDownload(const QList<QString> & keys);
     void individualDownloadComplete(QString filename, bool hadError);
 
 protected slots:
@@ -105,7 +105,6 @@ private:
     int activeDownloadCount;
     QString _extension;
     QSet<QString> currentlyDownloading;
-    bool _bulkDownloadStarting;
     QTimer _bulkDownloadTimer;
     QList<QString> _curBulkDownloadKeys;
     QList<QString>::const_iterator _bulkDownloadPos;

--- a/src/model/imageprovider.h
+++ b/src/model/imageprovider.h
@@ -98,6 +98,8 @@ private:
     int activeDownloadCount;
     QString _extension;
     QSet<QString> currentlyDownloading;
+    bool _bulkDownloadStarting;
+    bool _downloadCompletePending;
 };
 
 class URLFormatImageProvider : public ImageProvider {

--- a/src/model/imageprovider.h
+++ b/src/model/imageprovider.h
@@ -82,6 +82,7 @@ public:
 
 signals:
     void downloadComplete();
+    void bulkDownloadComplete();
 
 public slots:
     bool bulkDownload(const QList<QString> & keys);
@@ -108,7 +109,6 @@ private:
     QTimer _bulkDownloadTimer;
     QList<QString> _curBulkDownloadKeys;
     QList<QString>::const_iterator _bulkDownloadPos;
-    bool _downloadCompletePending;
 };
 
 class URLFormatImageProvider : public ImageProvider {

--- a/src/model/imageprovider.h
+++ b/src/model/imageprovider.h
@@ -24,6 +24,7 @@
 #include <QSet>
 #include <QQuickImageProvider>
 #include <QNetworkReply>
+#include <QTimer>
 
 // Handles state for an individual download
 class DownloadHandler : public QObject
@@ -86,10 +87,15 @@ public slots:
     bool bulkDownload(const QList<QString> & keys);
     void individualDownloadComplete(QString filename, bool hadError);
 
+protected slots:
+    void bulkDownloadStep();
+
 protected:
     virtual const QUrl getUrlForKey(QString & key) = 0;
 
 private:
+    static const int MSEC_PER_DOWNLOAD;
+
     QNetworkAccessManager _manager;
 
     QHash<QString, QImage*> _imageTable;
@@ -99,6 +105,9 @@ private:
     QString _extension;
     QSet<QString> currentlyDownloading;
     bool _bulkDownloadStarting;
+    QTimer _bulkDownloadTimer;
+    QList<QString> _curBulkDownloadKeys;
+    QList<QString>::const_iterator _bulkDownloadPos;
     bool _downloadCompletePending;
 };
 

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -1046,6 +1046,6 @@ void IrcChat::handleDownloadComplete() {
     }
 }
 
-bool IrcChat::bulkDownloadEmotes(QList<QString> keys) {
-    return _emoteProvider.bulkDownload(keys);
+void IrcChat::bulkDownloadEmotes(QList<QString> keys) {
+    _emoteProvider.bulkDownload(keys);
 }

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -50,6 +50,7 @@ IrcChat::IrcChat(QObject *parent) :
     logged_in = false;
 
     connect(&_emoteProvider, &ImageProvider::downloadComplete, this, &IrcChat::handleDownloadComplete);
+    connect(&_emoteProvider, &ImageProvider::bulkDownloadComplete, this, &IrcChat::bulkDownloadComplete);
 
     room = "";
 

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -121,7 +121,7 @@ public slots:
     void onSockStateChanged();
     void login();
 
-    bool bulkDownloadEmotes(QList<QString> keys);
+    void bulkDownloadEmotes(QList<QString> keys);
 
 private slots:
     void receive();

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -113,6 +113,8 @@ signals:
 
     void downloadComplete();
     bool downloadError();
+
+    void bulkDownloadComplete();
     
 public slots:
     void sendMessage(const QString &msg, const QVariantMap &relevantEmotes);

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -25,7 +25,7 @@ Item {
     signal notify(string message)
     signal clear()
     signal emoteSetIDsChanged(var emoteSetIDs)
-    signal downloadComplete()
+    signal bulkDownloadComplete()
     signal channelBadgeUrlsLoaded(string channel, var badgeUrls)
     signal channelBadgeBetaUrlsLoaded(string channel, var badgeSetData)
 
@@ -159,9 +159,8 @@ Item {
             root.emoteSetIDsChanged(emoteSetIDs)
         }
 
-        onDownloadComplete: {
-            console.log("inner download complete");
-            root.downloadComplete();
+        onBulkDownloadComplete: {
+            root.bulkDownloadComplete();
         }
     }
 }

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -817,6 +817,8 @@ Item {
         property var globalBetaBadgeSetData: {}
         property var lastBetaBadgeSetData: {}
 
+        property bool debugOutput: false
+
         onLastEmoteSetsChanged: {
             initEmotesMaps();
         }
@@ -896,7 +898,7 @@ Item {
         }
 
         onMessageReceived: {
-            //console.log("ChatView chat override onMessageReceived; typeof message " + typeof(message) + " toString: " + message.toString())
+            if (debugOutput) console.log("ChatView chat override onMessageReceived; typeof message " + typeof(message) + " toString: " + message.toString());
 
             if (chatColor != "") {
                 colors[user] = chatColor;
@@ -908,17 +910,17 @@ Item {
 
             // ListElement doesn't support putting in an array value, ugh.
             var serializedMessage = JSON.stringify(message);
-            console.log("onMessageReceived: passing: " + serializedMessage);
+            if (debugOutput) console.log("onMessageReceived: passing: " + serializedMessage);
 
             var badgeEntries = [];
             var imageFormatToUse = "image";
             var badgesSeen = {};
 
-            console.log("badges for this message:")
+            if (debugOutput) console.log("badges for this message:")
             for (var k = 0; k < badges.length; k++) {
                 var badgeName = badges[k][0];
                 var versionStr = badges[k][1];
-                console.log("  badge", badgeName, versionStr);
+                if (debugOutput) console.log("  badge", badgeName, versionStr);
 
                 if (badgesSeen[badgeName]) {
                     continue;
@@ -938,7 +940,7 @@ Item {
                         console.log("  available versions are", keysStr(badgeSetData))
                     } else {
                         var entry = {"name": versionObj.title, "url": badgeLocalUrl, "click_action": versionObj.click_action, "click_url": versionObj.click_url}
-                        console.log("adding entry", JSON.stringify(entry));
+                        if (debugOutput) console.log("adding entry", JSON.stringify(entry));
                         badgeEntries.push(entry);
                         curBadgeAdded = true;
                     }
@@ -946,12 +948,14 @@ Item {
 
                 var badgeUrls = lastBadgeUrls[badgeName];
                 if (!curBadgeAdded && badgeUrls != null) {
-                    console.log("  badge urls:")
-                    for (var j in badgeUrls) {
-                        console.log("    key", j, "value", badgeUrls[j]);
+                    if (debugOutput) {
+                        console.log("  badge urls:")
+                        for (var j in badgeUrls) {
+                            console.log("    key", j, "value", badgeUrls[j]);
+                        }
                     }
                     var entry = {"name": badgeName, "url": badgeLocalUrl};
-                    console.log("adding entry", JSON.stringify(entry));
+                    if (debugOutput) console.log("adding entry", JSON.stringify(entry));
                     badgeEntries.push(entry);
                     curBadgeAdded = true;
                 }

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -758,12 +758,7 @@ Item {
                             }
                             curDownloading ++;
                             console.log("Downloading emote set #", curDownloading, curSetID);
-                            var waitForDownload = chat.bulkDownloadEmotes(curSetList);
-
-                            if (!waitForDownload) {
-                                showLastSet();
-                                nextDownload();
-                            }
+                            chat.bulkDownloadEmotes(curSetList);
                         } else {
                             emotePickerDownloadsInProgress = false;
                             _emotePicker.loading = false;
@@ -786,7 +781,7 @@ Item {
 
                 Connections {
                     target: chat
-                    onDownloadComplete: {
+                    onBulkDownloadComplete: {
                         //console.log("outer download complete");
                         if (_emoteButton.emotePickerDownloadsInProgress) {
                             //console.log("handling emote picker set finished");


### PR DESCRIPTION
Adds some timer delays in the bulk emote download when the emote picker is first opened, to reduce the impact on the currently playing video and allow chat emote downloads to happen concurrently.

I also disabled a bunch of the debug output about badges.