### PR TITLE
Focus the emote search box immediately after emote picker is opened

### DIFF
--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -428,6 +428,7 @@ Item {
 
         onVisibleChanged: {
             if (visible) {
+                focusFilterInput();
                 height = dp(320);
             }
         }
@@ -561,9 +562,6 @@ Item {
                     onVisibleChanged: {
                         if (_emotePicker.visible && !_emoteButton.pickerLoaded) {
                             loadEmotes();
-                        }
-                        if (_emotePicker.visible) {
-                            _emotePicker.focusFilterInput();
                         }
                     }
                 }


### PR DESCRIPTION
Fix for https://github.com/rakslice/orion/issues/4 ; I'm not sure if this is a 100% fix, but I'm not able to reproduce the problem after this change