### PR TITLE
Double join chat quick fix

### DIFF
--- a/src/network/networkmanager.cpp
+++ b/src/network/networkmanager.cpp
@@ -135,7 +135,7 @@ void NetworkManager::testConnection()
     QNetworkRequest request;
     request.setRawHeader("Accept", "application/vnd.twitchtv.v5+json");
     request.setRawHeader("Client-ID", getClientId().toUtf8());
-    request.setUrl(QUrl(TWITCH_API_BASE));
+    request.setUrl(QUrl(KRAKEN_API));
 
     QNetworkReply *reply = operation->get(request);
 

--- a/src/network/urls.h
+++ b/src/network/urls.h
@@ -17,7 +17,6 @@
 
 #define KRAKEN_API "https://api.twitch.tv/kraken"
 #define TWITCH_API "https://api.twitch.tv/api"
-#define TWITCH_API_BASE "https://api.twitch.tv/kraken/base"
 #define TWITCH_RECHAT_API "https://rechat.twitch.tv/rechat-messages"
 #define TWITCH_TMI_USER_API "https://tmi.twitch.tv/group/user/"
 //#define TWITCH_EMOTES "http://static-cdn.jtvnw.net/emoticons/v1/"

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -28,7 +28,6 @@ Item {
     signal bulkDownloadComplete()
     signal channelBadgeUrlsLoaded(int channelId, var badgeUrls)
     signal channelBadgeBetaUrlsLoaded(string channel, var badgeSetData)
-    signal channelBitsUrlsLoaded(int channelID, var bitsUrls)
 
     property alias isAnonymous: chat.anonymous
     property var channel: undefined
@@ -64,11 +63,6 @@ Item {
         onChannelBadgeBetaUrlsLoaded: {
             console.log("onChannelBadgeBetaUrlsLoaded", "channel", channel, "badgeSetData", badgeSetData);
             root.channelBadgeBetaUrlsLoaded(channel, badgeSetData);
-        }
-
-        onChannelBitsUrlsLoaded: {
-            console.log("onChannelBitsUrlsLoaded", "channelID", channelID, "bitsUrls", bitsUrls);
-            root.channelBitsUrlsLoaded(channelID, bitsUrls);
         }
     }
 


### PR DESCRIPTION
The request `NetworkManager::testConnection()` was doing is not present in the v5 API and results in an error; as a quick fix I changed it to do a different request that succeeds when the network is up. I also removed an unused incorrectly-typed QML signal handler.
