### PR TITLE
More fixes for the Twitch API v5 changes

### DIFF
--- a/src/model/channel.cpp
+++ b/src/model/channel.cpp
@@ -58,29 +58,8 @@ Channel::Channel(){
     favourite = false;
 }
 
-Channel::Channel(const QString &uri) : Channel(){
-    this->serviceName = uri;
-}
-
-Channel::Channel(const QString &uri, const QString &name, const QString &info) : Channel(uri){
-    this->name = name;
-    this->info = info;
-}
-
-Channel::Channel(const QString &uri, const QString &name, const QString &info, bool alert) : Channel(name,uri,info){
-    this->alert = alert;
-}
-
-Channel::Channel(const QString &uri, const QString &name, const QString &info, bool alert, time_t time) : Channel(name,uri,info,alert){
-    this->timestamp = time;
-}
-
-Channel::Channel(const QString &uri, const QString &name, const QString &info, bool alert, time_t time, const QString &logo) : Channel(name,uri,info,alert,time){
-    this->logouri = logo;
-}
-
-Channel::Channel(const QString &uri, const QString &name, const QString &info, bool alert, time_t time, const QString &logo, const QString &preview) : Channel(name,uri,info,alert,time,logo){
-    this->previewuri = preview;
+Channel::Channel(const quint64 newId) : Channel() {
+    this->id = newId;
 }
 
 Channel::Channel(const Channel &channel){

--- a/src/model/channel.h
+++ b/src/model/channel.h
@@ -46,12 +46,7 @@ class Channel: public QObject{
 
 	public:
         Channel();
-        Channel(const QString&);
-        Channel(const QString&, const QString&, const QString&);
-        Channel(const QString&, const QString&, const QString&, bool);
-        Channel(const QString&, const QString&, const QString&, bool, time_t);
-        Channel(const QString&, const QString&, const QString&, bool, time_t, const QString&);
-        Channel(const QString&, const QString&, const QString&, bool, time_t, const QString&, const QString&);
+        Channel(const quint64);
         Channel(const Channel&);
         ~Channel();
         void updateWith(const Channel &other);

--- a/src/model/channellistmodel.cpp
+++ b/src/model/channellistmodel.cpp
@@ -236,9 +236,9 @@ bool ChannelListModel::updateStream(Channel *item)
 {
     bool onlineStateChanged = false;
 
-    if (item && !item->getServiceName().isEmpty()){
+    if (item && item->getId()){
 
-        if (Channel *channel = find(item->getServiceName())){
+        if (Channel *channel = find(item->getId())){
 
             if (item->isOnline()){
                 channel->setViewers(item->getViewers());
@@ -259,6 +259,9 @@ bool ChannelListModel::updateStream(Channel *item)
                 //emit channelOnlineStateChanged(channel);
             }
         }
+    }
+    else {
+        qDebug() << "ChannelListModel::updateStream got an item without id" << item->getServiceName();
     }
 
     return onlineStateChanged;

--- a/src/network/networkmanager.h
+++ b/src/network/networkmanager.h
@@ -108,7 +108,7 @@ signals:
     void m3u8OperationBFinished(const QVariantMap&);
     void fileOperationFinished(const QByteArray&);
     void favouritesReplyFinished(const QList<Channel *>&, const quint32);
-    void streamGetOperationFinished(const QString channelName, const bool online);
+    void streamGetOperationFinished(const quint64 channelId, const bool online);
     void error(const QString &error);
 
     //oauth

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -96,8 +96,8 @@ Item {
         }
 
         onStreamGetOperationFinished: {
-            //console.log("Received stream status", channelName, online)
-            if (channelName === currentChannel.name) {
+            //console.log("Received stream status", channelId, currentChannel._id, online)
+            if (channelId === currentChannel._id) {
                 if (online && !root.streamOnline) {
                     console.log("Stream back online, resuming playback")
                     loadAndPlay(currentQualityName)

--- a/src/util/jsonparser.h
+++ b/src/util/jsonparser.h
@@ -42,7 +42,7 @@ public:
     static QList<Vod *> parseVods(const QByteArray&);
     static Game* parseGame(const QJsonObject&);
     static Channel* parseStream(const QByteArray&);
-    static Channel* parseStreamJson(const QJsonObject&);
+    static Channel* parseStreamJson(const QJsonObject&, const bool expectChannel);
     static Channel* parseChannel(const QByteArray&);
     static Channel* parseChannelJson(const QJsonObject&);
     static Vod* parseVod(const QJsonObject&);


### PR DESCRIPTION
Since the v5 API change, channels in the followed view continue to show as online after they have gone offline.

I found that it was up to code in `JsonParser` to determine which channels had gone offline, and to do this it required the current URL from `_links` collection in the response, which is no longer present in v5.

- Reworked response handling that depended on "_links" collections that are gone in v5
- Refactored things in `JsonParser` that depend on request URL up to `NetworkManager`
- Changed channel matching in `ChannelListModel::updateStream` to use ids
- Removed unused Channel constructors