### PR TITLE
Fix blank offline notifications

### DIFF
--- a/src/model/channellistmodel.cpp
+++ b/src/model/channellistmodel.cpp
@@ -250,6 +250,13 @@ bool ChannelListModel::updateStream(Channel *item)
                 }
             }
 
+            if (!item->isOnline()) {
+                // put some information back for notifications
+                if (!channel->getName().isEmpty()) {
+                    item->setName(channel->getName());
+                }
+            }
+
             if (channel->isOnline() != item->isOnline()){
                 channel->setOnline(item->isOnline());
                 updateChannelForView(channel);

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -326,6 +326,10 @@ void ChannelManager::setAccessToken(const QString &arg)
     }
 
     else {
+        // if we just logged out there are user settings to clear
+        user_id = 0;
+        user_name = "";
+
         //Reload local favourites from memory
         if (tempFavourites) {
             delete favouritesModel;

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -379,21 +379,22 @@ void ChannelManager::load(){
         minimizeOnStartup = settings.value("minimizeOnStartup").toBool();
     }
 
-    if (settings.contains("channels")) {
+    int size = settings.beginReadArray("channels");
+    if (size > 0) {
         QList<Channel*> _channels;
 
-        int size = settings.beginReadArray("channels");
-
-        for(int i=0; i<size; i++){
+        for (int i = 0; i < size; i++) {
             settings.setArrayIndex(i);
-            _channels.append(new Channel(settings));
+            Channel * channel = new Channel(settings);
+            channel->setFavourite(false); // for visual consistency we don't want to show favourite highlight on entries in the favourites model
+            _channels.append(channel);
         }
-        settings.endArray();
 
         favouritesModel->addAll(_channels);
 
         qDeleteAll(_channels);
     }
+    settings.endArray();
 
     if (settings.contains("access_token")) {
         setAccessToken(settings.value("access_token").toString());


### PR DESCRIPTION
Offline notifications were coming up with an empty channel name as offline channels' placeholder entries aren't created with one anymore.  Add it from the `favouritesModel` lookup. 