### PR TITLE
fix VOD reload going back to the beginning with Qt Multimedia backend

### DIFF
--- a/src/qml/MultimediaBackend.qml
+++ b/src/qml/MultimediaBackend.qml
@@ -18,7 +18,7 @@ import "components"
 import "irc"
 import "styles.js" as Styles
 
-/* Interface for backend Mpv
+/* Interface for backend Multimedia
 
 Functions needed:
 load(src, start)    -- Loads stream src, if given, start sets the starting milliseconds in vods
@@ -36,7 +36,7 @@ playingStopped()    -- Signaled when playback stops (stream ends)
 volumeChanged()     -- Signaled when volume changes internally
 
 Variables needed:
-status              -- string "PLAYING" | "PAUSED" | "STOPPED"
+status              -- string "PLAYING" | "PAUSED" | "STOPPING" | "STOPPED"
 position            -- Milliseconds in playback
 volume              -- volume between 0 - 100
 
@@ -67,11 +67,12 @@ Item {
     }
 
     function stop() {
+        status = "STOPPING";
         renderer.stop()
     }
 
     function togglePause() {
-        if (status == "PAUSED" || status == "STOPPED")
+        if (status == "PAUSED" || status == "STOPPING" || status == "STOPPED")
             resume()
         else
             pause()
@@ -139,6 +140,10 @@ Item {
         }
 
         onPositionChanged: {
+            if (root.status == "STOPPING" && position == 0) {
+                // suppress this position update; during a reload we want to resume from the previous playing position
+                return;
+            }
             var pos = position / 1000
             if (root.position !== pos)
                 root.position = pos


### PR DESCRIPTION
While doing one more test with the the Multimedia backend, I thought I might to find some work around for the issue of VODs restarting at the beginning on reload.  The problem wasn't what I expected.