### PR TITLE
Chat user blocks support

### DIFF
--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -192,7 +192,10 @@ ChannelManager::ChannelManager(NetworkManager *netman, bool hiDpi) : netman(netm
     connect(netman, SIGNAL(vodStartGetOperationFinished(double)), this, SIGNAL(vodStartGetOperationFinished(double)));
     connect(netman, SIGNAL(vodChatPieceGetOperationFinished(QList<ReplayChatMessage>)), this, SIGNAL(vodChatPieceGetOperationFinished(QList<ReplayChatMessage>)));
     connect(netman, SIGNAL(chatterListLoadOperationFinished(QMap<QString, QList<QString>>)), this, SLOT(processChatterList(QMap<QString, QList<QString>>)));
+
     connect(netman, SIGNAL(blockedUserListLoadOperationFinished(const QList<QString> &, const quint32)), this, SLOT(addBlockedUserResults(const QList<QString> &, const quint32)));
+    connect(netman, &NetworkManager::userBlocked, this, &ChannelManager::innerUserBlocked);
+    connect(netman, &NetworkManager::userUnblocked, this, &ChannelManager::innerUserUnblocked);
 
     connect(netman, SIGNAL(networkAccessChanged(bool)), this, SLOT(onNetworkAccessChanged(bool)));
     load();
@@ -1066,4 +1069,22 @@ void ChannelManager::setOfflineNotifications(bool value) {
 
 bool ChannelManager::getOfflineNotifications() {
     return offlineNotifications;
+}
+
+void ChannelManager::editUserBlock(const QString & blockUserName, const bool isBlock) {
+    if (isAccessTokenAvailable()) {
+        netman->editUserBlock(accessToken(), user_id, blockUserName, isBlock);
+    }
+}
+
+void ChannelManager::innerUserBlocked(quint64 myUserId, const QString & blockedUsername) {
+    if (user_id == myUserId) {
+        emit userBlocked(blockedUsername);
+    }
+}
+
+void ChannelManager::innerUserUnblocked(quint64 myUserId, const QString & unblockedUsername) {
+    if (user_id == myUserId) {
+        emit userUnblocked(unblockedUsername);
+    }
 }

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -978,10 +978,8 @@ const quint32 ChannelManager::BLOCKED_USER_LIST_FETCH_LIMIT = 100;
 
 void ChannelManager::getBlockedUserList()
 {
-    quint32 limit = 100;
     blockedUserListLoading.clear();
     netman->getBlockedUserList(accessToken(), user_id, 0, BLOCKED_USER_LIST_FETCH_LIMIT);
-
 }
 
 void ChannelManager::addBlockedUserResults(const QList<QString> & list, const quint32 nextOffset)

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -192,6 +192,8 @@ public:
 
     void setOfflineNotifications(bool value);
     bool getOfflineNotifications();
+
+    void editUserBlock(const QString & blockUserName, const bool isBlock);
     
     BadgeImageProvider * getBadgeImageProvider() {
         return &badgeImageProvider;
@@ -297,6 +299,9 @@ signals:
     void chatterListLoaded(QVariantMap chatters);
     void blockedUsersLoaded(const QSet<QString> &);
 
+    void userBlocked(const QString & blockedUsername);
+    void userUnblocked(const QString & unblockedUsername);
+
 public slots:
     void checkFavourites();
     void addToFavourites(const quint32&);
@@ -328,6 +333,8 @@ private slots:
     void onNetworkAccessChanged(bool);
     void processChatterList(QMap<QString, QList<QString>> chatters);
     void addBlockedUserResults(const QList<QString> & list, const quint32 nextOffset);
+    void innerUserBlocked(quint64 myUserId, const QString & blockedUsername);
+    void innerUserUnblocked(quint64 myUserId, const QString & unblockedUsername);
 };
 
 #endif //CHANNEL_MANAGER_H

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -120,6 +120,11 @@ protected:
     BadgeImageProvider badgeImageProvider;
     BitsImageProvider bitsImageProvider;
 
+    QList<QString> blockedUserListLoading;
+
+    static const quint32 BLOCKED_USER_LIST_FETCH_LIMIT;
+    void getBlockedUserList();
+
 public:
     ChannelManager(NetworkManager *netman, bool hiDpi);
     ~ChannelManager();
@@ -290,6 +295,7 @@ signals:
     void vodChatPieceGetOperationFinished(QList<ReplayChatMessage>);
 
     void chatterListLoaded(QVariantMap chatters);
+    void blockedUsersLoaded(const QSet<QString> &);
 
 public slots:
     void checkFavourites();
@@ -321,6 +327,7 @@ private slots:
     void addFollowedResults(const QList<Channel*>&, const quint32);
     void onNetworkAccessChanged(bool);
     void processChatterList(QMap<QString, QList<QString>> chatters);
+    void addBlockedUserResults(const QList<QString> & list, const quint32 nextOffset);
 };
 
 #endif //CHANNEL_MANAGER_H

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -522,9 +522,9 @@ void IrcChat::sendMessage(const QString &msg, const QVariantMap &relevantEmotes)
             }
         }
         
-        for (const QString & prefix : { "/block ", "/unblock " }) {
+        for (const QString & prefix : { "/block ", "/ignore ", "/unblock ", "/unignore " }) {
             if (displayMessage.toLower().startsWith(prefix)) {
-                bool isBlock = prefix == "/block ";
+                bool isBlock = (prefix == "/block ") || (prefix == "/ignore ");
                 QString username = displayMessage.mid(prefix.length());
                 setUserBlock(username, isBlock);
                 return;
@@ -1231,7 +1231,7 @@ void IrcChat::setUserBlock(const QString & username, const bool blocked) {
 
 void IrcChat::userBlocked(const QString & blockedUsername) {
     QString newBlockedUsername = blockedUsername.toLower();
-    emit noticeReceived("Blocked user " + blockedUsername);
+    emit noticeReceived("User " + blockedUsername + " successfully ignored");
     if (!blockedUsers.contains(newBlockedUsername)) {
         blockedUsers.insert(newBlockedUsername);
     }
@@ -1239,7 +1239,7 @@ void IrcChat::userBlocked(const QString & blockedUsername) {
 
 void IrcChat::userUnblocked(const QString & unblockedUsername) {
     QString newUnblockedUsername = unblockedUsername.toLower();
-    emit noticeReceived("Unblocked user " + newUnblockedUsername);
+    emit noticeReceived("User " + newUnblockedUsername + " successfully unignored");
     if (blockedUsers.contains(newUnblockedUsername)) {
         blockedUsers.remove(newUnblockedUsername);
     }

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -134,6 +134,7 @@ private slots:
     void handleVodStartTime(double);
     void handleDownloadedReplayChat(QList<ReplayChatMessage>);
     void handleChannelBitsUrlsLoaded(const int channelID, BitsQStringsMap bitsUrls);
+    void blockedUsersLoaded(const QSet<QString> &);
 
 private:
     static bool hiDpi;
@@ -152,6 +153,8 @@ private:
     ChannelManager * _cman;
     
     QList<ChatMessage> msgQueue;
+
+    QSet<QString> blockedUsers;
 
     void parseCommand(QString cmd);
 

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -135,6 +135,8 @@ private slots:
     void handleDownloadedReplayChat(QList<ReplayChatMessage>);
     void handleChannelBitsUrlsLoaded(const int channelID, BitsQStringsMap bitsUrls);
     void blockedUsersLoaded(const QSet<QString> &);
+    void userBlocked(const QString & blockedUsername);
+    void userUnblocked(const QString & unblockedUsername);
 
 private:
     static bool hiDpi;
@@ -223,6 +225,8 @@ private:
     void checkBitsRegex(const QRegExp & regex, const QString & prefix, const QString & message, ImagePositionsMap & mapToUpdate);
 
     void roomInitCommon(const QString channel, const QString channelId);
+
+    void setUserBlock(const QString & username, const bool blocked);
 };
 
 #endif // IRCCHAT_H

--- a/src/network/networkmanager.cpp
+++ b/src/network/networkmanager.cpp
@@ -429,6 +429,98 @@ void NetworkManager::getBlockedUserList(const QString &access_token, const quint
     connect(reply, SIGNAL(finished()), this, SLOT(blockedUserListReply()));
 }
 
+void NetworkManager::editUserBlock(const QString &access_token, const quint64 myUserId, const QString & blockUsername, const bool isBlock) {
+    const QString url = QString(KRAKEN_API) + QString("/users?login=") + QUrl::toPercentEncoding(blockUsername);
+
+    QNetworkRequest request;
+    request.setRawHeader("Accept", "application/vnd.twitchtv.v5+json");
+    request.setRawHeader("Client-ID", getClientId().toUtf8());
+    request.setUrl(url);
+
+    request.setAttribute(QNetworkRequest::User, myUserId);
+    request.setAttribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 1), blockUsername);
+    request.setAttribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 2), isBlock);
+    request.setAttribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 3), access_token);
+
+    QNetworkReply *reply = operation->get(request);
+
+    connect(reply, SIGNAL(finished()), this, SLOT(blockUserLookupReply()));
+}
+
+void NetworkManager::blockUserLookupReply() {
+    QNetworkReply* reply = qobject_cast<QNetworkReply *>(sender());
+
+    if (!handleNetworkError(reply)) {
+        return;
+    }
+
+    quint64 myUserId = reply->request().attribute(QNetworkRequest::User).toULongLong();
+    QString blockUsername = reply->request().attribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 1)).toString();
+    bool isBlock = reply->request().attribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 2)).toBool();
+    QString access_token = reply->request().attribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 3)).toString();
+
+    QByteArray data = reply->readAll();
+    const auto & userIds = JsonParser::parseUsers(data);
+
+    if (userIds.length() == 0 || userIds[0] == 0) {
+        qDebug() << "userId lookup failed for" << blockUsername;
+    }
+
+    quint64 blockUserId = userIds[0];
+
+    editUserBlockWithId(access_token, myUserId, blockUsername, blockUserId, isBlock);
+}
+
+void NetworkManager::editUserBlockWithId(const QString &access_token, const quint64 myUserId, const QString & blockUsername, const quint64 blockUserId, const bool isBlock) {
+    qDebug() << "Setting block for user" << blockUserId << "to" << isBlock << "for user" << myUserId;
+    const QString url = QString(KRAKEN_API) + QString("/users/") + QString::number(myUserId) + QString("/blocks/") + QString::number(blockUserId);
+    qDebug() << "Request" << url;
+
+    QNetworkRequest request;
+    request.setRawHeader("Accept", "application/vnd.twitchtv.v5+json");
+    request.setRawHeader("Client-ID", getClientId().toUtf8());
+    request.setUrl(url);
+
+    request.setAttribute(QNetworkRequest::User, myUserId);
+    request.setAttribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 1), blockUsername);
+    request.setAttribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 2), isBlock);
+
+    QString auth = "OAuth " + access_token;
+    request.setRawHeader(QString("Authorization").toUtf8(), auth.toUtf8());
+
+    QNetworkReply *reply;
+    if (isBlock) {
+        reply = operation->put(request, "");
+    }
+    else {
+        reply = operation->deleteResource(request);
+    }
+
+    connect(reply, SIGNAL(finished()), this, SLOT(blockUserReply()));
+}
+
+void NetworkManager::blockUserReply() {
+    QNetworkReply* reply = qobject_cast<QNetworkReply *>(sender());
+
+    if (!handleNetworkError(reply)) {
+        int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (statusCode == 401) {
+            qWarning() << "Warning: Not authorized to edit blocked users list; logout and log in again to update OAuth scopes";
+        }
+        return;
+    }
+
+    quint64 myUserId = reply->request().attribute(QNetworkRequest::User).toULongLong();
+    QString blockUsername = reply->request().attribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 1)).toString();
+    bool isBlock = reply->request().attribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 2)).toBool();
+
+    if (isBlock) {
+        emit userBlocked(myUserId, blockUsername);
+    }
+    else {
+        emit userUnblocked(myUserId, blockUsername);
+    }
+}
 
 void NetworkManager::chatterListReply() {
     QNetworkReply* reply = qobject_cast<QNetworkReply *>(sender());
@@ -436,8 +528,6 @@ void NetworkManager::chatterListReply() {
     if (!handleNetworkError(reply)) {
         return;
     }
-
-    reply->url().query();
 
     QByteArray data = reply->readAll();
 
@@ -465,7 +555,7 @@ void NetworkManager::blockedUserListReply() {
 
     QList<QString> ret = JsonParser::parseBlockList(data);
 
-    int nextOffset = reply->attribute(QNetworkRequest::User).toInt();
+    int nextOffset = reply->request().attribute(QNetworkRequest::User).toInt();
 
     emit blockedUserListLoadOperationFinished(ret, nextOffset);
 

--- a/src/network/networkmanager.h
+++ b/src/network/networkmanager.h
@@ -87,6 +87,7 @@ public:
     Q_INVOKABLE void cancelLastVodChatRequest();
     Q_INVOKABLE void resetVodChat();
     Q_INVOKABLE void loadChatterList(const QString channel);
+    void getBlockedUserList(const QString &access_token, const quint64 userId, const quint32 offset, const quint32 limit);
 
     QNetworkAccessManager *getManager() const;
 
@@ -122,6 +123,7 @@ signals:
     void vodStartGetOperationFinished(double);
     void vodChatPieceGetOperationFinished(QList<ReplayChatMessage>);
     void chatterListLoadOperationFinished(QMap<QString, QList<QString>>);
+    void blockedUserListLoadOperationFinished(QList<QString>, const quint32 nextOffset);
 
     void getChannelBitsUrlsOperationFinished(int channelID, BitsQStringsMap channelBitsUrls, BitsQStringsMap channelBitsColors);
     void getGlobalBitsUrlsOperationFinished(BitsQStringsMap globalBitsUrls, BitsQStringsMap globalBitsColors);
@@ -148,6 +150,7 @@ private slots:
     void vodStartReply();
     void vodChatPieceReply();
     void chatterListReply();
+    void blockedUserListReply();
 
     //Oauth slots
     void userReply();

--- a/src/network/networkmanager.h
+++ b/src/network/networkmanager.h
@@ -88,6 +88,7 @@ public:
     Q_INVOKABLE void resetVodChat();
     Q_INVOKABLE void loadChatterList(const QString channel);
     void getBlockedUserList(const QString &access_token, const quint64 userId, const quint32 offset, const quint32 limit);
+    void editUserBlock(const QString &access_token, const quint64 myUserId, const QString & blockUserName, const bool isBlock);
 
     QNetworkAccessManager *getManager() const;
 
@@ -130,6 +131,9 @@ signals:
 
     void networkAccessChanged(bool up);
 
+    void userBlocked(quint64 myUserId, const QString & blockedUsername);
+    void userUnblocked(quint64 myUserId, const QString & unblockedUsername);
+
 private slots:
     void testNetworkInterface();
     void testConnection();
@@ -151,6 +155,7 @@ private slots:
     void vodChatPieceReply();
     void chatterListReply();
     void blockedUserListReply();
+    void blockUserReply();
 
     //Oauth slots
     void userReply();
@@ -160,6 +165,7 @@ private slots:
     void globalBadgeUrlsBetaReply();
     void channelBitsUrlsReply();
     void globalBitsUrlsReply();
+    void blockUserLookupReply();
 
 private:
     static const QString CHANNEL_BADGES_URL_PREFIX;
@@ -183,6 +189,8 @@ private:
     void filterReplayChat(QList<ReplayChatMessage> & replayChat);
 
     QNetworkReply *lastVodChatRequest;
+
+    void editUserBlockWithId(const QString &access_token, const quint64 myUserId, const QString & blockUsername, const quint64 blockUserId, const bool isBlock);
 };
 
 #endif // NETWORKMANAGER_H

--- a/src/qml/OptionsView.qml
+++ b/src/qml/OptionsView.qml
@@ -184,7 +184,7 @@ Item{
                         httpServer.start();
                         var url = "https://api.twitch.tv/kraken/oauth2/authorize?response_type=token&client_id=" + netman.getClientId()
                                 + "&redirect_uri=http://localhost:8979"
-                                + "&scope=user_read%20user_subscriptions%20user_follows_edit%20chat_login%20user_blocks_read"
+                                + "&scope=user_read%20user_subscriptions%20user_follows_edit%20chat_login%20user_blocks_read%20user_blocks_edit"
                                 + "&force_verify=true";
                         Qt.openUrlExternally(url);
 

--- a/src/qml/OptionsView.qml
+++ b/src/qml/OptionsView.qml
@@ -184,7 +184,7 @@ Item{
                         httpServer.start();
                         var url = "https://api.twitch.tv/kraken/oauth2/authorize?response_type=token&client_id=" + netman.getClientId()
                                 + "&redirect_uri=http://localhost:8979"
-                                + "&scope=user_read%20user_subscriptions%20user_follows_edit%20chat_login"
+                                + "&scope=user_read%20user_subscriptions%20user_follows_edit%20chat_login%20user_blocks_read"
                                 + "&force_verify=true";
                         Qt.openUrlExternally(url);
 

--- a/src/util/jsonparser.cpp
+++ b/src/util/jsonparser.cpp
@@ -681,3 +681,27 @@ QMap<QString, QList<QString>> JsonParser::parseChatterList(const QByteArray &dat
     return out;
     
 }
+
+QList<QString> JsonParser::parseBlockList(const QByteArray &data)
+{
+    QList<QString> out;
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(data, &error);
+
+    if (error.error == QJsonParseError::NoError) {
+        QJsonObject json = doc.object();
+
+        QJsonArray blocks = json["blocks"].toArray();
+
+        for (const auto & block : blocks) {
+            const auto & blockObj = block.toObject();
+            const auto & name = blockObj["user"].toObject()["name"].toString();
+            if (!name.isEmpty()) {
+                out.append(name);
+            }
+        }
+    }
+
+    return out;
+}

--- a/src/util/jsonparser.cpp
+++ b/src/util/jsonparser.cpp
@@ -413,6 +413,29 @@ QPair<QString, quint64> JsonParser::parseUser(const QByteArray &data)
     return qMakePair(displayName, userId);
 }
 
+QList<quint64> JsonParser::parseUsers(const QByteArray &data)
+{
+    QList<quint64> out;
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(data, &error);
+
+    if (error.error == QJsonParseError::NoError) {
+        QJsonObject json = doc.object();
+        for (const auto & user : json["users"].toArray()) {
+            auto userId = user.toObject()["_id"];
+            if (userId.isDouble()) {
+                out.append(static_cast<quint64>(userId.toDouble()));
+            }
+            else {
+                out.append(userId.toString().toULongLong());
+            }
+        }
+    }
+
+    return out;
+}
+
 QMap<int, QMap<int, QString>> JsonParser::parseEmoteSets(const QByteArray &data) {
     QMap<int, QMap<int, QString>> out;
 

--- a/src/util/jsonparser.h
+++ b/src/util/jsonparser.h
@@ -49,6 +49,7 @@ public:
     static QString parseChannelStreamExtractionInfo(const QByteArray&);
     static QString parseVodExtractionInfo(const QByteArray&);
     static QPair<QString, quint64> parseUser(const QByteArray&);
+    static QList<quint64> parseUsers(const QByteArray&);
     static int parseTotal(const QByteArray&);
     static QMap<int, QMap<int, QString>> parseEmoteSets(const QByteArray&);
     static QMap<QString, QMap<QString, QString>> parseChannelBadgeUrls(const QByteArray &data);

--- a/src/util/jsonparser.h
+++ b/src/util/jsonparser.h
@@ -55,6 +55,7 @@ public:
     static QMap<QString, QMap<QString, QMap<QString, QString>>> parseBadgeUrlsBetaFormat(const QByteArray &data);
     static QList<ReplayChatMessage> parseVodChatPiece(const QByteArray &data);
     static QMap<QString, QList<QString>> parseChatterList(const QByteArray &data);
+    static QList<QString> parseBlockList(const QByteArray &data);
     static void parseBitsData(const QByteArray &data, QMap<QString, QMap<QString, QString>> & outUrls, QMap<QString, QMap<QString, QString>> & outColors);
     static void setHiDpi(bool setting);
 private:


### PR DESCRIPTION
- Load the current Twitch user's blocked users list on login
- Don't display messages from blocked users
- Don't display whispers from blocked users
- Support chat commands `/block {username}` and `/unblock {username}` to block and unblock users

There doesn't seem to be a way to get notified when a user is blocked or unblocked by issuing a command in another chat session; you need to reload to get updated blocks. The Twitch web UI also has this problem.
