### PR TITLE
Switch to function-pointer-style QObject::connect()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     SysTray *tray = new SysTray();
     tray->setIcon(appIcon);
 
-    QObject::connect(tray, SIGNAL(closeEventTriggered()), &app, SLOT(quit()));
+    QObject::connect(tray, &SysTray::closeEventTriggered, &app, &CustomApp::quit);
 
     //Prime network manager
     QNetworkProxyFactory::setUseSystemConfiguration(true);
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 
     //Http server used for auth
     HttpServer *httpserver = new HttpServer(&app);
-    QObject::connect(httpserver, SIGNAL(codeReceived(QString)), cman, SLOT(setAccessToken(QString)));
+    QObject::connect(httpserver, &HttpServer::codeReceived, cman, &ChannelManager::setAccessToken);
     //-------------------------------------------------------------------------------------------------------------------//
 
     qreal dpiMultiplier = QGuiApplication::primaryScreen()->logicalDotsPerInch();
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
 
     //Set up notifications
     NotificationManager *notificationManager = new NotificationManager(&engine, engine.networkAccessManager());
-    QObject::connect(cman, SIGNAL(pushNotification(QString,QString,QString)), notificationManager, SLOT(pushNotification(QString,QString,QString)));
+    QObject::connect(cman, &ChannelManager::pushNotification, notificationManager, &NotificationManager::pushNotification);
 
     qDebug() << "Starting window...";
     tray->show();

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -135,8 +135,8 @@ ChannelListModel *ChannelManager::createFollowedChannelsModel()
 {
     ChannelListModel *model = new ChannelListModel();
 
-    connect(model, SIGNAL(channelOnlineStateChanged(Channel*)), this, SLOT(notify(Channel*)));
-    connect(model, SIGNAL(multipleChannelsChangedOnline(const QList<Channel*> &)), this, SLOT(notifyMultipleChannelsOnline(const QList<Channel*> &)));
+    connect(model, &ChannelListModel::channelOnlineStateChanged, this, &ChannelManager::notify);
+    connect(model, &ChannelListModel::multipleChannelsChangedOnline, this, &ChannelManager::notifyMultipleChannelsOnline);
 
     return model;
 }
@@ -171,33 +171,33 @@ ChannelManager::ChannelManager(NetworkManager *netman, bool hiDpi) : netman(netm
     featuredProxy->setSortRole(ChannelListModel::Roles::ViewersRole);
     featuredProxy->sort(0, Qt::DescendingOrder);
 
-    connect(netman, SIGNAL(allStreamsOperationFinished(const QList<Channel*>&)), this, SLOT(updateStreams(QList<Channel*>)));
-    connect(netman, SIGNAL(featuredStreamsOperationFinished(const QList<Channel*>&)), this, SLOT(addFeaturedResults(QList<Channel*>)));
-    connect(netman, SIGNAL(gamesOperationFinished(const QList<Game*>&)), this, SLOT(addGames(QList<Game*>)));
-    connect(netman, SIGNAL(gameStreamsOperationFinished(const QList<Channel*>&)), this, SLOT(addSearchResults(QList<Channel*>)));
-    connect(netman, SIGNAL(searchChannelsOperationFinished(const QList<Channel*>&)), this, SLOT(addSearchResults(QList<Channel*>)));
-    connect(netman, SIGNAL(m3u8OperationFinished(QVariantMap)), this, SIGNAL(foundPlaybackStream(QVariantMap)));
-    connect(netman, SIGNAL(searchGamesOperationFinished(QList<Game*>)), this, SLOT(addGames(QList<Game*>)));
+    connect(netman, &NetworkManager::allStreamsOperationFinished, this, &ChannelManager::updateStreams);
+    connect(netman, &NetworkManager::featuredStreamsOperationFinished, this, &ChannelManager::addFeaturedResults);
+    connect(netman, &NetworkManager::gamesOperationFinished, this, &ChannelManager::addGames);
+    connect(netman, &NetworkManager::gameStreamsOperationFinished, this, &ChannelManager::addSearchResults);
+    connect(netman, &NetworkManager::searchChannelsOperationFinished, this, &ChannelManager::addSearchResults);
+    connect(netman, &NetworkManager::m3u8OperationFinished, this, &ChannelManager::foundPlaybackStream);
+    connect(netman, &NetworkManager::searchGamesOperationFinished, this, &ChannelManager::addGames);
 
-    connect(netman, SIGNAL(userOperationFinished(QString, quint64)), this, SLOT(onUserUpdated(QString, quint64)));
-    connect(netman, SIGNAL(getEmoteSetsOperationFinished(const QMap<int, QMap<int, QString>>)), this, SLOT(onEmoteSetsUpdated(const QMap<int, QMap<int, QString>>)));
-    connect(netman, SIGNAL(getChannelBadgeUrlsOperationFinished(const quint64, const QMap<QString, QMap<QString, QString>>)), this, SLOT(innerChannelBadgeUrlsLoaded(const quint64, const QMap<QString, QMap<QString, QString>>)));
-    connect(netman, SIGNAL(getChannelBadgeBetaUrlsOperationFinished(const int, const QMap<QString, QMap<QString, QMap<QString, QString>>>)), this, SLOT(innerChannelBadgeBetaUrlsLoaded(const int, const QMap<QString, QMap<QString, QMap<QString, QString>>>)));
-    connect(netman, SIGNAL(getGlobalBadgeBetaUrlsOperationFinished(const QMap<QString, QMap<QString, QMap<QString, QString>>>)), this, SLOT(innerGlobalBadgeBetaUrlsLoaded(const QMap<QString, QMap<QString, QMap<QString, QString>>>)));
+    connect(netman, &NetworkManager::userOperationFinished, this, &ChannelManager::onUserUpdated);
+    connect(netman, &NetworkManager::getEmoteSetsOperationFinished, this, &ChannelManager::onEmoteSetsUpdated);
+    connect(netman, &NetworkManager::getChannelBadgeUrlsOperationFinished, this, &ChannelManager::innerChannelBadgeUrlsLoaded);
+    connect(netman, &NetworkManager::getChannelBadgeBetaUrlsOperationFinished, this, &ChannelManager::innerChannelBadgeBetaUrlsLoaded);
+    connect(netman, &NetworkManager::getGlobalBadgeBetaUrlsOperationFinished, this, &ChannelManager::innerGlobalBadgeBetaUrlsLoaded);
 
-    connect(netman, SIGNAL(getChannelBitsUrlsOperationFinished(int, BitsQStringsMap, BitsQStringsMap)), this, SLOT(innerChannelBitsDataLoaded(int, BitsQStringsMap, BitsQStringsMap)));
-    connect(netman, SIGNAL(getGlobalBitsUrlsOperationFinished(BitsQStringsMap, BitsQStringsMap)), this, SLOT(innerGlobalBitsDataLoaded(BitsQStringsMap, BitsQStringsMap)));
+    connect(netman, &NetworkManager::getChannelBitsUrlsOperationFinished, this, &ChannelManager::innerChannelBitsDataLoaded);
+    connect(netman, &NetworkManager::getGlobalBitsUrlsOperationFinished, this, &ChannelManager::innerGlobalBitsDataLoaded);
 
-    connect(netman, SIGNAL(favouritesReplyFinished(const QList<Channel*>&, const quint32)), this, SLOT(addFollowedResults(const QList<Channel*>&, const quint32)));
-    connect(netman, SIGNAL(vodStartGetOperationFinished(double)), this, SIGNAL(vodStartGetOperationFinished(double)));
-    connect(netman, SIGNAL(vodChatPieceGetOperationFinished(QList<ReplayChatMessage>)), this, SIGNAL(vodChatPieceGetOperationFinished(QList<ReplayChatMessage>)));
-    connect(netman, SIGNAL(chatterListLoadOperationFinished(QMap<QString, QList<QString>>)), this, SLOT(processChatterList(QMap<QString, QList<QString>>)));
+    connect(netman, &NetworkManager::favouritesReplyFinished, this, &ChannelManager::addFollowedResults);
+    connect(netman, &NetworkManager::vodStartGetOperationFinished, this, &ChannelManager::vodStartGetOperationFinished);
+    connect(netman, &NetworkManager::vodChatPieceGetOperationFinished, this, &ChannelManager::vodChatPieceGetOperationFinished);
+    connect(netman, &NetworkManager::chatterListLoadOperationFinished, this, &ChannelManager::processChatterList);
 
-    connect(netman, SIGNAL(blockedUserListLoadOperationFinished(const QList<QString> &, const quint32)), this, SLOT(addBlockedUserResults(const QList<QString> &, const quint32)));
+    connect(netman, &NetworkManager::blockedUserListLoadOperationFinished, this, &ChannelManager::addBlockedUserResults);
     connect(netman, &NetworkManager::userBlocked, this, &ChannelManager::innerUserBlocked);
     connect(netman, &NetworkManager::userUnblocked, this, &ChannelManager::innerUserUnblocked);
 
-    connect(netman, SIGNAL(networkAccessChanged(bool)), this, SLOT(onNetworkAccessChanged(bool)));
+    connect(netman, &NetworkManager::networkAccessChanged, this, &ChannelManager::onNetworkAccessChanged);
     load();
 }
 

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -32,7 +32,7 @@ ImageProvider::ImageProvider(const QString imageProviderName, const QString exte
 
     _bulkDownloadTimer.setInterval(MSEC_PER_DOWNLOAD);
     _bulkDownloadTimer.setSingleShot(true);
-    connect(&_bulkDownloadTimer, SIGNAL(timeout()), this, SLOT(bulkDownloadStep()));
+    connect(&_bulkDownloadTimer, &QTimer::timeout, this, &ImageProvider::bulkDownloadStep);
 
     QString useCacheDirName = cacheDirName != "" ? cacheDirName : imageProviderName;
     _cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QString("/" + useCacheDirName);

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -79,11 +79,11 @@ void IrcChat::initSocket() {
         emit errorOccured("Error creating socket");
     }
     else {
-        connect(sock, SIGNAL(readyRead()), this, SLOT(receive()));
-        connect(sock, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(processError(QAbstractSocket::SocketError)));
-        connect(sock, SIGNAL(connected()), this, SLOT(login()));
-        connect(sock, SIGNAL(connected()), this, SLOT(onSockStateChanged()));
-        connect(sock, SIGNAL(disconnected()), this, SLOT(onSockStateChanged()));
+        connect(sock, &QTcpSocket::readyRead, this, &IrcChat::receive);
+        connect(sock, static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error), this, &IrcChat::processError);
+        connect(sock, &QTcpSocket::connected, this, &IrcChat::login);
+        connect(sock, &QTcpSocket::connected, this, &IrcChat::onSockStateChanged);
+        connect(sock, &QTcpSocket::disconnected, this, &IrcChat::onSockStateChanged);
     }
 }
 

--- a/src/model/vodmanager.cpp
+++ b/src/model/vodmanager.cpp
@@ -18,8 +18,8 @@ VodManager::VodManager(NetworkManager *netman) : netman(netman)
 {
     model = new VodListModel();
 
-    connect(netman, SIGNAL(broadcastsOperationFinished(QList<Vod*>)), this, SLOT(onSearchFinished(QList<Vod*>)));
-    connect(netman, SIGNAL(m3u8OperationBFinished(QVariantMap)), this, SIGNAL(streamsGetFinished(QVariantMap)));
+    connect(netman, &NetworkManager::broadcastsOperationFinished, this, &VodManager::onSearchFinished);
+    connect(netman, &NetworkManager::m3u8OperationBFinished, this, &VodManager::streamsGetFinished);
 }
 
 VodManager::~VodManager()

--- a/src/network/httpserver.h
+++ b/src/network/httpserver.h
@@ -64,13 +64,13 @@ public slots:
     void onConnect() {
         qDebug()<<"Connected";
         QTcpSocket *socket = server->nextPendingConnection();
-        connect(socket, SIGNAL(readyRead()), this, SLOT(onRead()));
+        connect(socket, &QTcpSocket::readyRead, this, &HttpServer::onRead);
     }
 
     void onRead() {
         qDebug() << "Reading request...";
         QTcpSocket *socket = (QTcpSocket*) this->sender();
-        socket->connect(socket, SIGNAL(disconnected()), SLOT(deleteLater()));
+        socket->connect(socket, &QTcpSocket::disconnected, &QObject::deleteLater);
 
         /// Read data
         QString code;

--- a/src/network/networkmanager.cpp
+++ b/src/network/networkmanager.cpp
@@ -32,14 +32,14 @@ NetworkManager::NetworkManager(QNetworkAccessManager *man)
     testNetworkInterface();
 
     //SSL errors handle (down the drain)
-    connect(operation, SIGNAL(sslErrors(QNetworkReply*,QList<QSslError>)), this, SLOT(handleSslErrors(QNetworkReply*,QList<QSslError>)));
+    connect(operation, &QNetworkAccessManager::sslErrors, this, &NetworkManager::handleSslErrors);
 
     //Handshake
     operation->connectToHost(TWITCH_API);
 
     //Set up offline poller
     offlinePoller.setInterval(2000);
-    connect(&offlinePoller, SIGNAL(timeout()), this, SLOT(testNetworkInterface()));
+    connect(&offlinePoller, &QTimer::timeout, this, &NetworkManager::testNetworkInterface);
 
     lastVodChatRequest = nullptr;
 }
@@ -60,7 +60,7 @@ void NetworkManager::testNetworkInterface()
     QString identifier;
 
     QEventLoop loop;
-    connect(this, SIGNAL(finishedConnectionTest()), &loop, SLOT(quit()));
+    connect(this, &NetworkManager::finishedConnectionTest, &loop, &QEventLoop::quit);
 
     //Test default configuration
     operation->setConfiguration(conf.defaultConfiguration());
@@ -141,7 +141,7 @@ void NetworkManager::testConnection()
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(testConnectionReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::testConnectionReply);
 }
 
 void NetworkManager::testConnectionReply()
@@ -170,7 +170,7 @@ void NetworkManager::getStream(const quint64 channelId)
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(streamReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::streamReply);
 }
 
 void NetworkManager::getStreams(const QString &url)
@@ -183,7 +183,7 @@ void NetworkManager::getStreams(const QString &url)
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(allStreamsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::allStreamsReply);
 }
 
 void NetworkManager::getGames(const quint32 &offset, const quint32 &limit)
@@ -198,7 +198,7 @@ void NetworkManager::getGames(const quint32 &offset, const quint32 &limit)
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(gamesReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::gamesReply);
 }
 
 void NetworkManager::searchChannels(const QString &query, const quint32 &offset, const quint32 &limit)
@@ -216,7 +216,7 @@ void NetworkManager::searchChannels(const QString &query, const quint32 &offset,
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(searchChannelsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::searchChannelsReply);
 }
 
 void NetworkManager::searchGames(const QString &query)
@@ -231,7 +231,7 @@ void NetworkManager::searchGames(const QString &query)
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(searchGamesReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::searchGamesReply);
 }
 
 void NetworkManager::getFeaturedStreams()
@@ -247,7 +247,7 @@ void NetworkManager::getFeaturedStreams()
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(featuredStreamsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::featuredStreamsReply);
 }
 
 void NetworkManager::getStreamsForGame(const QString &game, const quint32 &offset, const quint32 &limit)
@@ -263,7 +263,7 @@ void NetworkManager::getStreamsForGame(const QString &game, const quint32 &offse
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(gameStreamsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::gameStreamsReply);
 }
 
 void NetworkManager::getChannelPlaybackStream(const QString &channelName)
@@ -279,7 +279,7 @@ void NetworkManager::getChannelPlaybackStream(const QString &channelName)
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(streamExtractReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::streamExtractReply);
 }
 
 void NetworkManager::getBroadcasts(const quint64 channelId, quint32 offset, quint32 limit)
@@ -302,7 +302,7 @@ void NetworkManager::getBroadcasts(const quint64 channelId, quint32 offset, quin
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(broadcastsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::broadcastsReply);
 }
 
 void NetworkManager::getBroadcastPlaybackStream(const QString &vod)
@@ -318,7 +318,7 @@ void NetworkManager::getBroadcastPlaybackStream(const QString &vod)
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(streamExtractReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::streamExtractReply);
 }
 
 void NetworkManager::getUser(const QString &access_token)
@@ -334,7 +334,7 @@ void NetworkManager::getUser(const QString &access_token)
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(userReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::userReply);
 }
 
 void NetworkManager::getUserFavourites(const quint64 userId, quint32 offset, quint32 limit)
@@ -353,7 +353,7 @@ void NetworkManager::getUserFavourites(const quint64 userId, quint32 offset, qui
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(favouritesReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::favouritesReply);
 }
 
 void NetworkManager::getEmoteSets(const QString &access_token, const QList<int> &emoteSetIDs) {
@@ -376,7 +376,7 @@ void NetworkManager::getEmoteSets(const QString &access_token, const QList<int> 
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(emoteSetsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::emoteSetsReply);
 }
 
 void NetworkManager::getVodStartTime(quint64 vodId) {
@@ -390,7 +390,7 @@ void NetworkManager::getVodStartTime(quint64 vodId) {
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(vodStartReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::vodStartReply);
 
 }
 
@@ -405,7 +405,7 @@ void NetworkManager::loadChatterList(const QString channel) {
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(chatterListReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::chatterListReply);
 }
 
 void NetworkManager::getBlockedUserList(const QString &access_token, const quint64 userId, const quint32 offset, const quint32 limit) {
@@ -426,7 +426,7 @@ void NetworkManager::getBlockedUserList(const QString &access_token, const quint
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(blockedUserListReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::blockedUserListReply);
 }
 
 void NetworkManager::editUserBlock(const QString &access_token, const quint64 myUserId, const QString & blockUsername, const bool isBlock) {
@@ -444,7 +444,7 @@ void NetworkManager::editUserBlock(const QString &access_token, const quint64 my
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(blockUserLookupReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::blockUserLookupReply);
 }
 
 void NetworkManager::blockUserLookupReply() {
@@ -496,7 +496,7 @@ void NetworkManager::editUserBlockWithId(const QString &access_token, const quin
         reply = operation->deleteResource(request);
     }
 
-    connect(reply, SIGNAL(finished()), this, SLOT(blockUserReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::blockUserReply);
 }
 
 void NetworkManager::blockUserReply() {
@@ -574,7 +574,7 @@ void NetworkManager::getVodChatPiece(quint64 vodId, quint64 offset) {
 
     lastVodChatRequest = reply;
     
-    connect(reply, SIGNAL(finished()), this, SLOT(vodChatPieceReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::vodChatPieceReply);
 }
 
 void NetworkManager::cancelLastVodChatRequest() {
@@ -713,7 +713,7 @@ void NetworkManager::getChannelBadgeUrls(const QString &access_token, const quin
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(channelBadgeUrlsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::channelBadgeUrlsReply);
 }
 
 const QString NetworkManager::CHANNEL_BADGES_BETA_URL_PREFIX = "https://badges.twitch.tv/v1/badges/channels/";
@@ -732,7 +732,7 @@ void NetworkManager::getChannelBadgeUrlsBeta(const int channelID) {
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(channelBadgeUrlsBetaReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::channelBadgeUrlsBetaReply);
 }
 
 void NetworkManager::getGlobalBadgesUrlsBeta() {
@@ -747,7 +747,7 @@ void NetworkManager::getGlobalBadgesUrlsBeta() {
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(globalBadgeUrlsBetaReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::globalBadgeUrlsBetaReply);
 }
 
 void NetworkManager::getChannelBitsUrls(const int channelID) {
@@ -762,7 +762,7 @@ void NetworkManager::getChannelBitsUrls(const int channelID) {
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(channelBitsUrlsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::channelBitsUrlsReply);
 }
 
 void NetworkManager::channelBitsUrlsReply() {
@@ -808,7 +808,7 @@ void NetworkManager::getGlobalBitsUrls() {
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(globalBitsUrlsReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::globalBitsUrlsReply);
 }
 
 void NetworkManager::globalBitsUrlsReply() {
@@ -851,7 +851,7 @@ void NetworkManager::editUserFavourite(const QString &access_token, const quint6
     else
         reply = operation->deleteResource(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(editUserFavouritesReply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::editUserFavouritesReply);
 }
 
 QNetworkAccessManager *NetworkManager::getManager() const
@@ -869,7 +869,7 @@ void NetworkManager::getM3U8Data(const QString &url, M3U8TYPE type)
 
     QNetworkReply *reply = operation->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(m3u8Reply()));
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::m3u8Reply);
 }
 
 bool NetworkManager::handleNetworkError(QNetworkReply *reply)

--- a/src/notification/notificationmanager.cpp
+++ b/src/notification/notificationmanager.cpp
@@ -23,7 +23,7 @@ NotificationManager::NotificationManager(QQmlApplicationEngine *engine, QNetwork
     queue.clear();
 
     timer = new QTimer();
-    connect(timer, SIGNAL(timeout()), this, SLOT(showNext()));
+    connect(timer, &QTimer::timeout, this, &NotificationManager::showNext);
     timer->setInterval(3000);
     timer->setSingleShot(true);
 

--- a/src/notification/notificationsender.cpp
+++ b/src/notification/notificationsender.cpp
@@ -48,7 +48,7 @@ void NotificationSender::getFile(const QString &url)
 
     QNetworkReply *reply = netman->get(request);
 
-    connect(reply, SIGNAL(finished()), this, SLOT(onFileReply()));
+    connect(reply, &QNetworkReply::finished, this, &NotificationSender::onFileReply);
 }
 
 

--- a/src/power/power.cpp
+++ b/src/power/power.cpp
@@ -28,7 +28,7 @@ Power::Power(QApplication *app) :
     app(app), cookie(0)
 {
     timer = new QTimer();
-    connect(timer, SIGNAL(timeout()), this, SLOT(onTimerProc()));
+    connect(timer, &QTimer::timeout, this, &Power::onTimerProc);
 }
 
 Power::~Power()

--- a/src/systray.cpp
+++ b/src/systray.cpp
@@ -22,15 +22,15 @@ SysTray::SysTray()
 
     QAction *show = new QAction(menu);
     show->setText("Show/Hide");
-    connect(show, SIGNAL(triggered(bool)), this, SLOT(showSlot()));
+    connect(show, &QAction::triggered, this, &SysTray::showSlot);
     menu->addAction(show);
 
     QAction *quit = new QAction(menu);
     quit->setText("Quit");
-    connect(quit, SIGNAL(triggered(bool)), this, SLOT(quitSlot()));
+    connect(quit, &QAction::triggered, this, &SysTray::quitSlot);
     menu->addAction(quit);
 
-    connect(this, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(clickSlot(QSystemTrayIcon::ActivationReason)));
+    connect(this, &SysTray::activated, this, &SysTray::clickSlot);
 
     setContextMenu(menu);
 }

--- a/src/util/runguard.cpp
+++ b/src/util/runguard.cpp
@@ -90,7 +90,7 @@ void RunGuard::release()
 void RunGuard::setTimer()
 {
     timer = new QTimer();
-    connect(timer, SIGNAL(timeout()), this, SLOT(update()));
+    connect(timer, &QTimer::timeout, this, &RunGuard::update);
     timer->start(250);
 }
 


### PR DESCRIPTION
Change `QObject::connect()` calls over to the function-pointer style introduced in Qt 5. https://doc.qt.io/qt-5/qobject.html#connect-3

In particular, this provides compile-time checking of parameter lists, avoiding situations where a function signature changes and a `connect()` call still builds but fails at runtime.

More backround: https://woboq.com/blog/new-signals-slots-syntax-in-qt5.html