### PR TITLE
Slight UI improvement

### DIFF
--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -389,6 +389,9 @@ Item {
                 if (sourcesBox.open){
                     sourcesBox.close()
                 }
+                if (smallMode) {
+                    requestSelectionChange(5)
+                }   
             }
 
             onDoubleClicked: {
@@ -738,7 +741,7 @@ Item {
                         delay: 666
                         text: "Toggle fullscreen"
                     }
-                }   
+                }
             }
 
             StreamSelectorComboBox {


### PR DESCRIPTION
Change: single clicking on the small player now makes it full screen. 

Reason: It annoyed me that you had to click on the player icon in the sidebar to return to fullscreen from the mini player. Looking through the code I figured out I needed to doubleclick, I never thought of that! A bit dumb I know. I think this change makes it a bit more intuitive.