### PR TITLE
hide chat controls in small mode

### DIFF
--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -163,6 +163,8 @@ Item {
         }
         height: dp(40)
 
+        visible: root.chatViewVisible
+
         IconButton {
             id: _viewerListButton
             icon: viewerListEnabled ? "times" : "list"


### PR DESCRIPTION
Fixes viewer list icon was showing up in the small mode view.

I made this change before but it probably got lost in move of the chat controls.