### PR TITLE
BTTV Emote Support

### DIFF
--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -114,6 +114,7 @@ protected:
     QMap<int, QMap<int, QString>> lastEmoteSets;
     QMap<QString, QMap<QString, QMap<QString, QString>>> channelBadgeUrls;
     QMap<QString, QMap<QString, QMap<QString, QMap<QString, QString>>>> channelBadgeBetaUrls;
+    QMap<QString, QMap<QString, QString>> channelBttvEmotes;
     QMap<int, QMap<QString, QMap<QString, QString>>> channelBitsUrls;
     QMap<int, QMap<QString, QMap<QString, QString>>> channelBitsColors;
 
@@ -178,6 +179,8 @@ public:
     Q_INVOKABLE bool loadChannelBetaBadgeUrls(int channel);
     Q_INVOKABLE bool loadChannelBitsUrls(int channel);
     Q_INVOKABLE void loadChatterList(const QString channel);
+
+    Q_INVOKABLE bool loadChannelBttvEmotes(const QString channel);
 
     Q_INVOKABLE void cancelLastVodChatRequest();
     Q_INVOKABLE void resetVodChat();
@@ -292,6 +295,8 @@ signals:
 
     void channelBitsUrlsLoaded(const int channelID, BitsQStringsMap bitsUrls, BitsQStringsMap bitsColors);
 
+    void channelBttvEmotesLoaded(const QString channel, QMap<QString, QString> emotesByCode);
+
     void vodStartGetOperationFinished(double);
     void vodChatPieceGetOperationFinished(QList<ReplayChatMessage>);
 
@@ -328,6 +333,8 @@ private slots:
     void innerGlobalBadgeBetaUrlsLoaded(const QMap<QString, QMap<QString, QMap<QString, QString>>> badgeData);
     void innerChannelBitsDataLoaded(int channelID, BitsQStringsMap channelBitsUrls, BitsQStringsMap channelBitsColors);
     void innerGlobalBitsDataLoaded(BitsQStringsMap globalBitsUrls, BitsQStringsMap globalBitsColors);
+    void innerChannelBttvEmotesLoaded(const QString channel, QMap<QString, QString> & emotesByCode);
+    void innerGlobalBttvEmotesLoaded(QMap<QString, QString> & emotesByCode);
     void addFollowedResults(const QList<Channel*>&, const quint32, const quint32);
     void onNetworkAccessChanged(bool);
     void processChatterList(QMap<QString, QList<QString>> chatters);

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -163,7 +163,7 @@ QQmlImageProviderBase * ImageProvider::getQMLImageProvider() {
     return new CachedImageProvider(_imageTable);
 }
 
-bool ImageProvider::downloadsInProgress() {
+bool ImageProvider::downloadsInProgress() const {
     return activeDownloadCount > 0;
 }
 

--- a/src/model/imageprovider.h
+++ b/src/model/imageprovider.h
@@ -70,7 +70,7 @@ public:
     * Returns true if caller should wait for a downloadComplete event before using the emote */
     bool makeAvailable(QString key);
     bool download(QString key);
-    bool downloadsInProgress();
+    bool downloadsInProgress() const;
 
     QHash<QString, QImage*> imageTable();
     void loadImageFile(QString key, QString filename);

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -37,6 +37,9 @@ const QString IrcChat::IMAGE_PROVIDER_EMOTE = "emote";
 const QString IrcChat::IMAGE_PROVIDER_BITS = "bits";
 const QString IrcChat::EMOTICONS_URL_FORMAT_LODPI = "https://static-cdn.jtvnw.net/emoticons/v1/%1/1.0";
 const QString IrcChat::EMOTICONS_URL_FORMAT_HIDPI = "https://static-cdn.jtvnw.net/emoticons/v1/%1/2.0";
+const QString IrcChat::IMAGE_PROVIDER_BTTV_EMOTE = "bttvemote";
+const QString IrcChat::BTTV_EMOTES_URL_FORMAT_LODPI = "https://cdn.betterttv.net/emote/%1/1x";
+const QString IrcChat::BTTV_EMOTES_URL_FORMAT_HIDPI = "https://cdn.betterttv.net/emote/%1/2x";
 
 const qint16 IrcChat::PORT = 443;
 const QString IrcChat::HOST = "irc.chat.twitch.tv";
@@ -55,6 +58,7 @@ bool IrcChat::getHiDpi() {
 IrcChat::IrcChat(QObject *parent) :
     QObject(parent),
     _emoteProvider(IMAGE_PROVIDER_EMOTE, hiDpi? EMOTICONS_URL_FORMAT_HIDPI : EMOTICONS_URL_FORMAT_LODPI, ".png", hiDpi? "emotes_2x" : "emotes"),
+    _bttvEmoteProvider(IMAGE_PROVIDER_BTTV_EMOTE, hiDpi? BTTV_EMOTES_URL_FORMAT_HIDPI : BTTV_EMOTES_URL_FORMAT_LODPI, ".png", hiDpi? "bttv_emotes_2x" : "bttv_emotes"),
     _bitsProvider(nullptr),
     _badgeProvider(nullptr),
     _cman(nullptr),
@@ -64,8 +68,11 @@ IrcChat::IrcChat(QObject *parent) :
 
     logged_in = false;
 
-    connect(&_emoteProvider, &ImageProvider::downloadComplete, this, &IrcChat::handleDownloadComplete);
-    connect(&_emoteProvider, &ImageProvider::bulkDownloadComplete, this, &IrcChat::bulkDownloadComplete);
+
+    for (const auto provider : { &_emoteProvider, &_bttvEmoteProvider }) {
+        connect(provider, &ImageProvider::downloadComplete, this, &IrcChat::handleDownloadComplete);
+        connect(provider, &ImageProvider::bulkDownloadComplete, this, &IrcChat::bulkDownloadComplete);
+    }
 
     room = "";
 
@@ -97,6 +104,7 @@ void IrcChat::initProviders() {
 
 void IrcChat::RegisterEngineProviders(QQmlEngine & engine) {
 	engine.addImageProvider(IMAGE_PROVIDER_EMOTE, _emoteProvider.getQMLImageProvider());
+    engine.addImageProvider(IMAGE_PROVIDER_BTTV_EMOTE, _bttvEmoteProvider.getQMLImageProvider());
     if (_badgeProvider) {
         engine.addImageProvider(_badgeProvider->getImageProviderName(), _badgeProvider->getQMLImageProvider());
     }
@@ -118,6 +126,7 @@ void IrcChat::hookupChannelProviders(ChannelManager * cman) {
         connect(_cman, &ChannelManager::vodStartGetOperationFinished, this, &IrcChat::handleVodStartTime);
         connect(_cman, &ChannelManager::vodChatPieceGetOperationFinished, this, &IrcChat::handleDownloadedReplayChat);
         connect(_cman, &ChannelManager::channelBitsUrlsLoaded, this, &IrcChat::handleChannelBitsUrlsLoaded);
+        connect(_cman, &ChannelManager::channelBttvEmotesLoaded, this, &IrcChat::handleChannelBttvEmotesLoaded);
         connect(_cman, &ChannelManager::blockedUsersLoaded, this, &IrcChat::blockedUsersLoaded);
         connect(_cman, &ChannelManager::userBlocked, this, &IrcChat::userBlocked);
         connect(_cman, &ChannelManager::userUnblocked, this, &IrcChat::userUnblocked);
@@ -125,6 +134,13 @@ void IrcChat::hookupChannelProviders(ChannelManager * cman) {
     else {
         qDebug() << "hookupChannelProviders got null";
     }
+}
+
+bool IrcChat::allDownloadsComplete() {
+    return !_emoteProvider.downloadsInProgress() &&
+        !_bttvEmoteProvider.downloadsInProgress() &&
+        _badgeProvider != nullptr && !_badgeProvider->downloadsInProgress() &&
+        _bitsProvider != nullptr && !_bitsProvider->downloadsInProgress();
 }
 
 IrcChat::~IrcChat() {
@@ -149,6 +165,8 @@ void IrcChat::roomInitCommon(const QString channel, const QString channelId) {
     if (_bitsProvider) {
         _bitsProvider->setChannelId(channelId.toInt());
     }
+
+    lastCurChannelBttvEmoteFixedStrings.clear();
 }
 
 void IrcChat::join(const QString channel, const QString channelId) {
@@ -424,17 +442,35 @@ QVariantList IrcChat::substituteEmotesInMessage(const QVariantList & message, co
 
     for (auto word = message.begin(); word != message.end(); word++) {
         bool spacePrefix = word != message.begin();
-        QString emoteText = spacePrefix ? word->toString().mid(1) : word->toString();
-        auto entry = relevantEmotes.find(emoteText);
-        if (entry != relevantEmotes.end()) {
+        QString possibleEmoteText = spacePrefix ? word->toString().mid(1) : word->toString();
+        bool isEmote = false;
+
+        auto entry = relevantEmotes.constFind(possibleEmoteText);
+        if (entry != relevantEmotes.constEnd()) {
             QString emoteId = entry.value().toString();
             _emoteProvider.makeAvailable(emoteId);
             if (spacePrefix) {
                 output.append(" ");
             }
-            output.append(createImageEntry(_emoteProvider.getImageProviderName(), emoteId, emoteText));
+            output.append(createImageEntry(_emoteProvider.getImageProviderName(), emoteId, possibleEmoteText));
+            isEmote = true;
         }
-        else {
+
+        for (const auto & emoteIndex : { lastCurChannelBttvEmoteFixedStrings, lastGlobalBttvEmoteFixedStrings }) {
+            auto entry = emoteIndex.constFind(possibleEmoteText);
+            if (entry != emoteIndex.constEnd()) {
+                QString emoteId = entry.value();
+                _bttvEmoteProvider.makeAvailable(emoteId);
+                if (spacePrefix) {
+                    output.append(" ");
+                }
+                output.append(createImageEntry(_bttvEmoteProvider.getImageProviderName(), emoteId, possibleEmoteText));
+                isEmote = true;
+                break;
+            }
+        }
+
+        if (!isEmote) {
             output.append(*word);
         }
     }
@@ -677,10 +713,6 @@ void IrcChat::addWordSplit(const QString & s, const QChar & sep, QVariantList & 
 	}
 }
 
-bool IrcChat::allDownloadsComplete() {
-    return !_emoteProvider.downloadsInProgress() && _badgeProvider && !_badgeProvider->downloadsInProgress() && _bitsProvider && !_bitsProvider->downloadsInProgress();
-}
-
 void IrcChat::disposeOfMessage(ChatMessage m) {
     if (allDownloadsComplete()) {
         emit messageReceived(m.name, m.messageList, m.color, m.subscriber, m.turbo, m.mod, m.isAction, m.badges, m.isChannelNotice, m.systemMessage, m.isWhisper);
@@ -836,6 +868,15 @@ void IrcChat::checkBitsRegex(const QRegExp & regex, const QString & prefix, cons
     }
 }
 
+void IrcChat::handleBttvEmote(const QString & id, ImagePositionsMap & mapToUpdate, int pos, int end) {
+    InlineImageInfo info;
+    info.kind = ImageEntryKind::bttvEmote;
+
+    info.key = _bttvEmoteProvider.getCanonicalKey(id);
+    mapToUpdate.insert(pos, qMakePair(end, info));
+    _bttvEmoteProvider.makeAvailable(id);
+}
+
 void updateBitsRegexes(const BitsQStringsMap & bitsUrls, QMap<QString, QRegExp> & mapToUpdate) {
     mapToUpdate.clear();
     
@@ -886,7 +927,31 @@ void IrcChat::createMessageList(const QMap<int, QPair<int, int>> & emotePosition
         }
     }
 
+    // check for space-separated fixed string tokens
     int cur = 0;
+    while (cur < message.length()) {
+        int wordEnd = message.indexOf(' ', cur);
+        if (wordEnd == -1) {
+            wordEnd = message.length();
+        }
+
+        if (wordEnd > cur) {
+            const auto word = message.mid(cur, wordEnd - cur);
+            
+            for (const QMap<QString, QString> & bttvIndex : { lastCurChannelBttvEmoteFixedStrings, lastGlobalBttvEmoteFixedStrings }) {
+                const auto matchEntry = bttvIndex.constFind(word);
+                if (matchEntry != bttvIndex.constEnd()) {
+                    handleBttvEmote(matchEntry.value(), imagePositionsMap, cur, wordEnd);
+                    break;
+                }
+            }
+        }
+
+        cur = wordEnd + 1;
+    }
+
+    // go through all text replacement image entries and cut up the input message
+    cur = 0;
     for (auto i = imagePositionsMap.constBegin(); i != imagePositionsMap.constEnd(); i++) {
         auto emoteStart = i.key();
         if (emoteStart > cur) {
@@ -900,24 +965,30 @@ void IrcChat::createMessageList(const QMap<int, QPair<int, int>> & emotePosition
         QString originalText = message.mid(emoteStart, emoteAfterEnd - emoteStart);
 
         QVariantMap imgEntry;
+        bool doInsert = true;
 
         switch (imageKind) {
         case ImageEntryKind::emote:
             imgEntry = createImageEntry(_emoteProvider.getImageProviderName(), imageId, originalText);
-            imgEntry.insert("textSuffix", imageInfo.textSuffix);
-            imgEntry.insert("textSuffixColor", imageInfo.textSuffixColor);
-            messageList.append(imgEntry);
+            break;
+        case ImageEntryKind::bttvEmote:
+            imgEntry = createImageEntry(_bttvEmoteProvider.getImageProviderName(), imageId, originalText);
             break;
         case ImageEntryKind::bits:
             if (_bitsProvider) {
                 imgEntry = createImageEntry(_bitsProvider->getImageProviderName(), imageId, originalText);
                 // currently QML AnimatedImage doesn't support using images from a QQuickImageProvider
                 imgEntry.insert("sourceUrl", _cman->getBitsUrlForKey(imageId).toString());
-                imgEntry.insert("textSuffix", imageInfo.textSuffix);
-                imgEntry.insert("textSuffixColor", imageInfo.textSuffixColor);
-                messageList.append(imgEntry);
+            }
+            else {
+                doInsert = false;
             }
             break;
+        }
+        if (doInsert) {
+            imgEntry.insert("textSuffix", imageInfo.textSuffix);
+            imgEntry.insert("textSuffixColor", imageInfo.textSuffixColor);
+            messageList.append(imgEntry);
         }
         cur = emoteAfterEnd;
     }
@@ -1255,3 +1326,14 @@ void IrcChat::userUnblocked(const QString & unblockedUsername) {
         blockedUsers.remove(newUnblockedUsername);
     }
 }
+
+void IrcChat::handleChannelBttvEmotesLoaded(const QString & channelName, QMap<QString, QString> emotesByCode) {
+    const QString GLOBAL_EMOTES_ID = "GLOBAL";
+    if (channelName == GLOBAL_EMOTES_ID) {
+        lastGlobalBttvEmoteFixedStrings = emotesByCode;
+    }
+    else if (channelName == room) {
+        lastCurChannelBttvEmoteFixedStrings = emotesByCode;
+    }
+}
+

--- a/src/model/ircchat.cpp
+++ b/src/model/ircchat.cpp
@@ -1303,6 +1303,22 @@ void IrcChat::bulkDownloadEmotes(QList<QString> keys) {
     _emoteProvider.bulkDownload(keys);
 }
 
+QList<QString> valuesList(const QMap<QString, QString> & map) {
+    QList<QString> out;
+    for (auto entry = map.constBegin(); entry != map.constEnd(); entry++) {
+        out.append(entry.value());
+    }
+    return out;
+}
+
+void IrcChat::downloadBttvEmotesGlobal() {
+    _bttvEmoteProvider.bulkDownload(valuesList(lastGlobalBttvEmoteFixedStrings));
+}
+
+void IrcChat::downloadBttvEmotesChannel() {
+    _bttvEmoteProvider.bulkDownload(valuesList(lastCurChannelBttvEmoteFixedStrings));
+}
+
 void IrcChat::blockedUsersLoaded(const QSet<QString> & newBlockedUsers) {
     blockedUsers = newBlockedUsers;
 }
@@ -1327,6 +1343,15 @@ void IrcChat::userUnblocked(const QString & unblockedUsername) {
     }
 }
 
+template <typename U>
+QVariantMap toVariantMap(const QMap<QString, U> & map) {
+    QVariantMap out;
+    for (auto entry = map.constBegin(); entry != map.constEnd(); entry++) {
+        out.insert(entry.key(), entry.value());
+    }
+    return out;
+}
+
 void IrcChat::handleChannelBttvEmotesLoaded(const QString & channelName, QMap<QString, QString> emotesByCode) {
     const QString GLOBAL_EMOTES_ID = "GLOBAL";
     if (channelName == GLOBAL_EMOTES_ID) {
@@ -1335,5 +1360,7 @@ void IrcChat::handleChannelBttvEmotesLoaded(const QString & channelName, QMap<QS
     else if (channelName == room) {
         lastCurChannelBttvEmoteFixedStrings = emotesByCode;
     }
+
+    emit bttvEmotesLoaded(channelName, toVariantMap(emotesByCode));
 }
 

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -139,6 +139,8 @@ private slots:
     void userBlocked(const QString & blockedUsername);
     void userUnblocked(const QString & unblockedUsername);
 
+    void handleChannelBttvEmotesLoaded(const QString & channelName, QMap<QString, QString> emotesByCode);
+
 private:
     static bool hiDpi;
 
@@ -148,9 +150,13 @@ private:
     static const QString IMAGE_PROVIDER_EMOTE;
     static const QString EMOTICONS_URL_FORMAT_HIDPI;
     static const QString EMOTICONS_URL_FORMAT_LODPI;
+    static const QString IMAGE_PROVIDER_BTTV_EMOTE;
+    static const QString BTTV_EMOTES_URL_FORMAT_HIDPI;
+    static const QString BTTV_EMOTES_URL_FORMAT_LODPI;
     static const QString IMAGE_PROVIDER_BITS;
 
     URLFormatImageProvider _emoteProvider;
+    URLFormatImageProvider _bttvEmoteProvider;
     BitsImageProvider * _bitsProvider;
     BadgeImageProvider * _badgeProvider;
     ChannelManager * _cman;
@@ -212,7 +218,10 @@ private:
     QMap<QString, QRegExp> lastCurChannelBitsRegexes;
     QMap<QString, QRegExp> lastGlobalBitsRegexes;
 
-    enum ImageEntryKind { emote, bits };
+    QMap<QString, QString> lastGlobalBttvEmoteFixedStrings;
+    QMap<QString, QString> lastCurChannelBttvEmoteFixedStrings;
+
+    enum ImageEntryKind { emote, bits, bttvEmote };
 
     struct InlineImageInfo {
         ImageEntryKind kind;
@@ -224,6 +233,8 @@ private:
     typedef QMap<int, QPair<int, InlineImageInfo>> ImagePositionsMap;
 
     void checkBitsRegex(const QRegExp & regex, const QString & prefix, const QString & message, ImagePositionsMap & mapToUpdate);
+
+    void handleBttvEmote(const QString & id, ImagePositionsMap & mapToUpdate, int pos, int end);
 
     void roomInitCommon(const QString channel, const QString channelId);
 

--- a/src/model/ircchat.h
+++ b/src/model/ircchat.h
@@ -119,6 +119,8 @@ signals:
     bool downloadError();
 
     void bulkDownloadComplete();
+
+    void bttvEmotesLoaded(QString channel, QVariantMap emotesByCode);
     
 public slots:
     void sendMessage(const QString &msg, const QVariantMap &relevantEmotes);
@@ -126,7 +128,8 @@ public slots:
     void login();
 
     void bulkDownloadEmotes(QList<QString> keys);
-
+    void downloadBttvEmotesGlobal();
+    void downloadBttvEmotesChannel();
 private slots:
     void receive();
     void processError(QAbstractSocket::SocketError socketError);

--- a/src/network/networkmanager.cpp
+++ b/src/network/networkmanager.cpp
@@ -831,6 +831,66 @@ void NetworkManager::globalBitsUrlsReply() {
     reply->deleteLater();
 }
 
+void NetworkManager::getChannelBttvEmotes(const QString channel) {
+    QString url = QString(BTTV_API) + QString("/channels/") + QUrl::toPercentEncoding(channel);
+
+    qDebug() << "Requesting" << url;
+
+    QNetworkRequest request;
+    request.setUrl(QUrl(url));
+
+    QNetworkReply *reply = operation->get(request);
+
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::channelBttvEmotesReply);
+}
+
+void NetworkManager::channelBttvEmotesReply() {
+    QNetworkReply* reply = qobject_cast<QNetworkReply *>(sender());
+
+    if (!handleNetworkError(reply)) {
+        return;
+    }
+    QByteArray data = reply->readAll();
+
+    auto url = reply->url();
+    QString urlString = url.toString();
+    QString channel = urlString.mid(urlString.lastIndexOf("/") + 1);
+
+    auto emotes = JsonParser::parseBttvEmotesData(data);
+
+    emit getChannelBttvEmotesOperationFinished(channel, emotes);
+
+    reply->deleteLater();
+}
+
+void NetworkManager::getGlobalBttvEmotes() {
+    QString url = QString(BTTV_API) + QString("/emotes");
+
+    qDebug() << "Requesting" << url;
+
+    QNetworkRequest request;
+    request.setUrl(QUrl(url));
+
+    QNetworkReply *reply = operation->get(request);
+
+    connect(reply, &QNetworkReply::finished, this, &NetworkManager::globalBttvEmotesReply);
+}
+
+void NetworkManager::globalBttvEmotesReply() {
+    QNetworkReply* reply = qobject_cast<QNetworkReply *>(sender());
+
+    if (!handleNetworkError(reply)) {
+        return;
+    }
+    QByteArray data = reply->readAll();
+
+    auto emotes = JsonParser::parseBttvEmotesData(data);
+
+    emit getGlobalBttvEmotesOperationFinished(emotes);
+
+    reply->deleteLater();
+}
+
 void NetworkManager::editUserFavourite(const QString &access_token, const quint64 userId, const quint64 channelId, bool add)
 {
     QString url = QString(KRAKEN_API) + "/users/" + QString::number(userId)

--- a/src/network/networkmanager.h
+++ b/src/network/networkmanager.h
@@ -81,6 +81,8 @@ public:
     void getGlobalBadgesUrlsBeta();
     void getChannelBitsUrls(const int channelID);
     void getGlobalBitsUrls();
+    void getChannelBttvEmotes(const QString channel);
+    void getGlobalBttvEmotes();
 
     Q_INVOKABLE void getVodStartTime(quint64 vodId);
     Q_INVOKABLE void getVodChatPiece(quint64 vodId, quint64 offset);
@@ -129,6 +131,9 @@ signals:
     void getChannelBitsUrlsOperationFinished(int channelID, BitsQStringsMap channelBitsUrls, BitsQStringsMap channelBitsColors);
     void getGlobalBitsUrlsOperationFinished(BitsQStringsMap globalBitsUrls, BitsQStringsMap globalBitsColors);
 
+    void getChannelBttvEmotesOperationFinished(const QString channel, QMap<QString, QString> & emotesByCode);
+    void getGlobalBttvEmotesOperationFinished(QMap<QString, QString> & emotesByCode);
+
     void networkAccessChanged(bool up);
 
     void userBlocked(quint64 myUserId, const QString & blockedUsername);
@@ -166,6 +171,8 @@ private slots:
     void channelBitsUrlsReply();
     void globalBitsUrlsReply();
     void blockUserLookupReply();
+    void globalBttvEmotesReply();
+    void channelBttvEmotesReply();
 
 private:
     static const QString CHANNEL_BADGES_URL_PREFIX;

--- a/src/network/urls.h
+++ b/src/network/urls.h
@@ -20,6 +20,7 @@
 #define TWITCH_RECHAT_API "https://rechat.twitch.tv/rechat-messages"
 #define TWITCH_TMI_USER_API "https://tmi.twitch.tv/group/user/"
 //#define TWITCH_EMOTES "http://static-cdn.jtvnw.net/emoticons/v1/"
+#define BTTV_API "https://api.betterttv.net/2"
 #define CLIENT_ID "0dpzlnp1w2bjlim3ldp0u96o4dq2gm"
 
 #endif // URLS_H

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -72,6 +72,7 @@ Item {
         g_cman.loadChannelBadgeUrls(channelId);
         g_cman.loadChannelBetaBadgeUrls(channelId);
         g_cman.loadChannelBitsUrls(channelId);
+        g_cman.loadChannelBttvEmotes(channelName);
     }
 
     function joinChannel(channelName, channelId) {

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -28,6 +28,7 @@ Item {
     signal bulkDownloadComplete()
     signal channelBadgeUrlsLoaded(int channelId, var badgeUrls)
     signal channelBadgeBetaUrlsLoaded(string channel, var badgeSetData)
+    signal bttvEmotesLoaded(string channel, var emotesByCode)
 
     property alias isAnonymous: chat.anonymous
     property var channel: undefined
@@ -124,6 +125,14 @@ Item {
         return chat.bulkDownloadEmotes(emotes);
     }
 
+    function downloadBttvEmotesGlobal() {
+        return chat.downloadBttvEmotesGlobal();
+    }
+
+    function downloadBttvEmotesChannel() {
+        return chat.downloadBttvEmotesChannel();
+    }
+
     function reconnect() {
         leaveChannel()
         if (root.channel)
@@ -168,6 +177,10 @@ Item {
 
         onBulkDownloadComplete: {
             root.bulkDownloadComplete();
+        }
+
+        onBttvEmotesLoaded: {
+            root.bttvEmotesLoaded(channel, emotesByCode);
         }
     }
 }

--- a/src/util/jsonparser.cpp
+++ b/src/util/jsonparser.cpp
@@ -732,3 +732,29 @@ PagedResult<QString> JsonParser::parseBlockList(const QByteArray &data)
 
     return out;
 }
+
+
+QMap<QString, QString> JsonParser::parseBttvEmotesData(const QByteArray &data)
+{
+    QMap<QString, QString> out;
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(data, &error);
+
+    if (error.error == QJsonParseError::NoError) {
+        QJsonObject json = doc.object();
+
+        QJsonArray emotes = json["emotes"].toArray();
+
+        for (const auto & emote : emotes) {
+            const auto & emoteObj = emote.toObject();
+            const auto & id = emoteObj["id"].toString();
+            const auto & code = emoteObj["code"].toString();
+            if (!id.isEmpty() && !code.isEmpty()) {
+                out.insert(code, id);
+            }
+        }
+    }
+
+    return out;
+}

--- a/src/util/jsonparser.h
+++ b/src/util/jsonparser.h
@@ -64,6 +64,7 @@ public:
     static QMap<QString, QList<QString>> parseChatterList(const QByteArray &data);
     static PagedResult<QString> parseBlockList(const QByteArray &data);
     static void parseBitsData(const QByteArray &data, QMap<QString, QMap<QString, QString>> & outUrls, QMap<QString, QMap<QString, QString>> & outColors);
+    static QMap<QString, QString> parseBttvEmotesData(const QByteArray &data);
     static void setHiDpi(bool setting);
 private:
     static bool hiDpi;


### PR DESCRIPTION
- Display BTTV emote images in sent and received messages, including global emotes and channel-specific emotes when in the relevant channel
- Load BTTV emotes in the emote picker, including channel specific emotes if any
- Remove channel specific emotes from the picker when the current channel changes

Re request https://github.com/alamminsalo/orion/issues/140