### PR TITLE
search request loop fix

### DIFF
--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -581,7 +581,7 @@ void ChannelManager::searchChannels(QString q, const quint32 &offset, const quin
     emit searchingStarted();
 }
 
-void ChannelManager::addSearchResults(const QList<Channel*> &list)
+void ChannelManager::addSearchResults(const QList<Channel*> &list, const int total)
 {
     bool needsStreamCheck = false;
 
@@ -600,7 +600,7 @@ void ChannelManager::addSearchResults(const QList<Channel*> &list)
 
     qDeleteAll(list);
 
-    emit resultsUpdated(numAdded);
+    emit resultsUpdated(numAdded, total);
 }
 
 void ChannelManager::getFeatured()

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -269,7 +269,7 @@ public:
 
 signals:
     void pushNotification(const QString &title, const QString &message, const QString &imgUrl);
-    void resultsUpdated(int numAdded);
+    void resultsUpdated(int numAdded, int total);
     void featuredUpdated();
     void searchingStarted();
     void foundPlaybackStream(const QVariantMap &streams);
@@ -316,7 +316,7 @@ public slots:
     void setAccessToken(const QString &arg);
 
 private slots:
-    void addSearchResults(const QList<Channel*>&);
+    void addSearchResults(const QList<Channel*>&, const int total);
     void addFeaturedResults(const QList<Channel*>&);
     void updateFavourites(const QList<Channel*>&);
     void updateStreams(const QList<Channel*>&);

--- a/src/network/networkmanager.cpp
+++ b/src/network/networkmanager.cpp
@@ -974,11 +974,11 @@ void NetworkManager::allStreamsReply()
         addULongLongStringList(queriedChannelIds, query.queryItemValue("channel").split(","));
     }
 
-    QList<Channel *> out = JsonParser::parseStreams(data);
+    PagedResult<Channel *> out = JsonParser::parseStreams(data);
 
-    addOfflineChannels(out, queriedChannelIds);
+    addOfflineChannels(out.items, queriedChannelIds);
 
-    emit allStreamsOperationFinished(out);
+    emit allStreamsOperationFinished(out.items);
 
     reply->deleteLater();
 }
@@ -1030,11 +1030,11 @@ void NetworkManager::gameStreamsReply()
         addULongLongStringList(queriedChannelIds, query.queryItemValue("channel").split(","));
     }
 
-    QList<Channel *> out = JsonParser::parseStreams(data);
+    PagedResult<Channel *> out = JsonParser::parseStreams(data);
 
-    addOfflineChannels(out, queriedChannelIds);
+    addOfflineChannels(out.items, queriedChannelIds);
 
-    emit gameStreamsOperationFinished(out);
+    emit gameStreamsOperationFinished(out.items, out.total);
 
     reply->deleteLater();
 }
@@ -1066,7 +1066,8 @@ void NetworkManager::searchChannelsReply()
 
     //qDebug() << data;
 
-    emit searchChannelsOperationFinished(JsonParser::parseChannels(data));
+    auto result = JsonParser::parseChannels(data);
+    emit searchChannelsOperationFinished(result.items, result.total);
 
     reply->deleteLater();
 }

--- a/src/network/networkmanager.h
+++ b/src/network/networkmanager.h
@@ -101,9 +101,9 @@ signals:
 
     void allStreamsOperationFinished(const QList<Channel *>&);
     void gamesOperationFinished(const QList<Game *>&);
-    void gameStreamsOperationFinished(const QList<Channel *>&);
+    void gameStreamsOperationFinished(const QList<Channel *>&, const int total);
     void featuredStreamsOperationFinished(const QList<Channel *>&);
-    void searchChannelsOperationFinished(const QList<Channel *>&);
+    void searchChannelsOperationFinished(const QList<Channel *>&, const int total);
     void searchGamesOperationFinished(const QList<Game *>&);
     void broadcastsOperationFinished(const QList<Vod *>&);
     void m3u8OperationFinished(const QVariantMap&);

--- a/src/qml/SearchView.qml
+++ b/src/qml/SearchView.qml
@@ -65,7 +65,7 @@ Item {
 
             _spinner.visible = false
             _button.visible = true
-            channels.checkScrolled()
+            channels.checkScrolled(total)
         }
 
         onSearchingStarted: {
@@ -191,7 +191,10 @@ Item {
 
         model: g_results
 
-        function checkScrolled(){
+        function checkScrolled(total){
+            if (total != null && itemCount >= total) {
+                return;
+            }
             if (atYEnd && model.count() === itemCount && itemCount > 0){
                 search(_input.text, itemCount, 25, false);
                 itemCount += 25

--- a/src/util/jsonparser.cpp
+++ b/src/util/jsonparser.cpp
@@ -20,9 +20,9 @@ void JsonParser::setHiDpi(bool setting) {
     hiDpi = setting;
 }
 
-QList<Channel*> JsonParser::parseStreams(const QByteArray &data)
+PagedResult<Channel*> JsonParser::parseStreams(const QByteArray &data)
 {
-    QList<Channel*> channels;
+    PagedResult<Channel*> out;
 
     QJsonParseError error;
     QJsonDocument doc = QJsonDocument::fromJson(data,&error);
@@ -32,13 +32,15 @@ QList<Channel*> JsonParser::parseStreams(const QByteArray &data)
         //Online streams
         QJsonArray arr = json["streams"].toArray();
         foreach (const QJsonValue &item, arr){
-            channels.append(JsonParser::parseStreamJson(item.toObject(), true));
+            out.items.append(JsonParser::parseStreamJson(item.toObject(), true));
         }
+
+        out.total = json["_total"].toInt();
 
         //Caller must use request context to determine offline streams
     }
 
-    return channels;
+    return out;
 }
 
 Channel *JsonParser::parseStream(const QByteArray &data)
@@ -252,9 +254,9 @@ Vod *JsonParser::parseVod(const QJsonObject &json)
     return vod;
 }
 
-QList<Channel*> JsonParser::parseChannels(const QByteArray &data)
+PagedResult<Channel*> JsonParser::parseChannels(const QByteArray &data)
 {
-    QList<Channel*> channels;
+    PagedResult<Channel*> out;
 
     QJsonParseError error;
     QJsonDocument doc = QJsonDocument::fromJson(data,&error);
@@ -263,11 +265,13 @@ QList<Channel*> JsonParser::parseChannels(const QByteArray &data)
 
         QJsonArray arr = json["channels"].toArray();
         foreach (const QJsonValue &item, arr){
-            channels.append(JsonParser::parseChannelJson(item.toObject()));
+            out.items.append(JsonParser::parseChannelJson(item.toObject()));
         }
+
+        out.total = json["_total"].toInt();
     }
 
-    return channels;
+    return out;
 }
 
 PagedResult<Channel *> JsonParser::parseFavourites(const QByteArray &data)

--- a/src/util/jsonparser.h
+++ b/src/util/jsonparser.h
@@ -40,9 +40,9 @@ struct PagedResult {
 class JsonParser
 {
 public:
-    static QList<Channel*> parseStreams(const QByteArray&);
+    static PagedResult<Channel*> parseStreams(const QByteArray&);
     static QList<Game*> parseGames(const QByteArray&);
-    static QList<Channel*> parseChannels(const QByteArray&);
+    static PagedResult<Channel*> parseChannels(const QByteArray&);
     static PagedResult<Channel*> parseFavourites(const QByteArray&);
     static QList<Channel*> parseFeatured(const QByteArray&);
     static QList<Vod *> parseVods(const QByteArray&);


### PR DESCRIPTION
- Collect `_total` values from responses to be shown in search view
- Don't do another request if the total from the response that triggered the request check indicates no more items are available.

This avoids the search view indefinitely cascading responses to requests, while still allowing the user to cause another request by doing any other action that causes a request check (e.g. dragging past the end)

Fixes https://github.com/alamminsalo/orion/issues/170.

