### PR TITLE
Debug command line option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,19 @@ int main(int argc, char *argv[])
         return -1;
     }
 
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Desktop client for Twitch.tv");
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    QCommandLineOption debugOption(QStringList() << "d" << "debug", "show debug output");
+
+    parser.addOption(debugOption);
+
+    parser.process(app);
+
+    bool showDebugOutput = parser.isSet(debugOption);
+
     //Init engine
     QQmlApplicationEngine engine;
 
@@ -67,7 +80,9 @@ int main(int argc, char *argv[])
         app.setFont(QFont(":/fonts/NotoSans-Regular.ttf", 10, QFont::Normal, false));
 
 #ifndef  QT_DEBUG
-    qInstallMessageHandler(noisyFailureMsgHandler);
+    if (!showDebugOutput) {
+        qInstallMessageHandler(noisyFailureMsgHandler);
+    }
 #endif
     app.setWindowIcon(appIcon);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@ inline void noisyFailureMsgHandler(QtMsgType /*type*/, const QMessageLogContext 
 int main(int argc, char *argv[])
 {
     CustomApp app(argc, argv);
+    app.setApplicationVersion(APP_VERSION);
 
     //Single application solution
     RunGuard guard("wz0dPKqHv3vX0BBsUFZt");


### PR DESCRIPTION
- Added `-d` / `--debug` command line option that enables debug output in release builds.
- Enabled other standard options (help, version)

Note that this doesn't change the nature of debug output when it is enabled (so for instance as the Windows build is not a console-mode executable, you need DebugView or other debug-enabled IDE to see its debug output)

Also, debug output remains always-enabled in debug builds.