### PR TITLE
Provide "Watch live" menu item even when channel is offline

### DIFF
--- a/src/qml/components/ChannelGrid.qml
+++ b/src/qml/components/ChannelGrid.qml
@@ -75,7 +75,7 @@ CommonGrid {
 
         MenuItem {
             id: _watchLive
-            text: _menu.item.online? "Watch live" : "Force watch live"
+            text: "Watch live"
             //text: "Watch;play"
             onTriggered: {
                 playerView.getStreams(_menu.item)

--- a/src/qml/components/ChannelGrid.qml
+++ b/src/qml/components/ChannelGrid.qml
@@ -31,8 +31,6 @@ CommonGrid {
     onItemRightClicked: {
         _menu.item = clickedItem
 
-        _watchLive.enabled = _menu.item.online
-
         _fav.text = (!allFavourites && !_menu.item.favourite) ? "Follow" : "Unfollow"
         _menu.state = (!allFavourites && !_menu.item.favourite) ? 1 : 2
 
@@ -77,12 +75,10 @@ CommonGrid {
 
         MenuItem {
             id: _watchLive
-            text: "Watch live"
+            text: _menu.item.online? "Watch live" : "Force watch live"
             //text: "Watch;play"
             onTriggered: {
-                if (_menu.item.online){
-                    playerView.getStreams(_menu.item)
-                }
+                playerView.getStreams(_menu.item)
             }
         }
 


### PR DESCRIPTION
Provides a way to open the stream for a channel when it is online but the API hasn't updated yet and is still indicating the channel is offline. Fixes https://github.com/alamminsalo/orion/issues/173.