### PR TITLE
VOD resume at last playback position

### DIFF
--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -520,6 +520,7 @@ void ChannelManager::setVodLastPlaybackPosition(const QString & channel, const Q
         vodEntry.value().modified = true;
     }
     else {
+        // -1 index to be replaced at settings save time
         vodMap.insert(vod, {position, true, -1});
     }
 

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -508,6 +508,8 @@ void ChannelManager::setVodLastPlaybackPosition(const QString & channel, const Q
     auto & vodMap = channelEntry.value();
     vodMap.remove(vod);
     vodMap.insert(vod, position);
+
+    emit vodLastPositionUpdated(channel, vod, position);
 }
 
 QVariant ChannelManager::getVodLastPlaybackPosition(const QString & channel, const QString & vod) {
@@ -523,6 +525,18 @@ QVariant ChannelManager::getVodLastPlaybackPosition(const QString & channel, con
     }
 
     return vodEntry.value();
+}
+
+QVariantMap ChannelManager::getChannelVodsLastPlaybackPositions(const QString & channel) {
+    QVariantMap out;
+    auto channelEntry = channelVodLastPositions.find(channel);
+    if (channelEntry != channelVodLastPositions.end()) {
+        auto & vodMap = channelEntry.value();
+        for (auto vodEntry = vodMap.constBegin(); vodEntry != vodMap.constEnd(); vodEntry++) {
+            out.insert(vodEntry.key(), vodEntry.value());
+        }
+    }
+    return out;
 }
 
 void ChannelManager::addToFavourites(const quint32 &id){

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -126,6 +126,8 @@ protected:
     static const quint32 BLOCKED_USER_LIST_FETCH_LIMIT;
     void getBlockedUserList();
 
+    QMap<QString, QMap<QString, quint64>> channelVodLastPositions;
+
 public:
     ChannelManager(NetworkManager *netman, bool hiDpi);
     ~ChannelManager();
@@ -186,6 +188,9 @@ public:
     Q_INVOKABLE void resetVodChat();
     Q_INVOKABLE void getVodStartTime(quint64 vodId);
     Q_INVOKABLE void getVodChatPiece(quint64 vodId, quint64 offset);
+
+    Q_INVOKABLE void setVodLastPlaybackPosition(const QString & channel, const QString & vod, quint64 position);
+    Q_INVOKABLE QVariant getVodLastPlaybackPosition(const QString & channel, const QString & vod);
 
     void setSwapChat(bool value);
     bool getSwapChat();

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -31,6 +31,12 @@
 
 class ChannelManager;
 
+struct LastPosition {
+    quint64 lastPosition;
+    bool modified;
+    int settingsIndex;
+};
+
 class BadgeImageProvider : public ImageProvider {
     Q_OBJECT
 public:
@@ -126,7 +132,9 @@ protected:
     static const quint32 BLOCKED_USER_LIST_FETCH_LIMIT;
     void getBlockedUserList();
 
-    QMap<QString, QMap<QString, quint64>> channelVodLastPositions;
+    QMap<QString, QMap<QString, LastPosition>> channelVodLastPositions;
+
+    void vodLastPlaybackPositionLoaded(const QString & channel, const QString & vod, quint64 position, int settingsIndex);
 
 public:
     ChannelManager(NetworkManager *netman, bool hiDpi);

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -191,6 +191,7 @@ public:
 
     Q_INVOKABLE void setVodLastPlaybackPosition(const QString & channel, const QString & vod, quint64 position);
     Q_INVOKABLE QVariant getVodLastPlaybackPosition(const QString & channel, const QString & vod);
+    Q_INVOKABLE QVariantMap getChannelVodsLastPlaybackPositions(const QString & channel);
 
     void setSwapChat(bool value);
     bool getSwapChat();
@@ -310,6 +311,8 @@ signals:
 
     void userBlocked(const QString & blockedUsername);
     void userUnblocked(const QString & unblockedUsername);
+
+    void vodLastPositionUpdated(const QString & channel, const QString & vod, const quint64 position);
 
 public slots:
     void checkFavourites();

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -29,6 +29,7 @@ Item {
     property var streamMap
     property bool isVod: false
     property bool streamOnline: true
+    property string curVodId
 
     property bool cursorHidden: false
     property string currentQualityName
@@ -156,18 +157,18 @@ Item {
         g_cman.setQuality(streamName);
     }
 
-    function getStreams(channel, vod){
-        getChannel(channel, vod, true);
+    function getStreams(channel, vod, startPos){
+        getChannel(channel, vod, true, startPos);
     }
 
     function getChat(channel) {
-        getChannel(channel, null, false);
+        getChannel(channel, null, false, 0);
         if (chatview.status == 0) {
             chatview.status++;
         }
     }
 
-    function getChannel(channel, vod, wantVideo){
+    function getChannel(channel, vod, wantVideo, startPos){
 
         if (!channel){
             return
@@ -185,12 +186,13 @@ Item {
             else {
                 g_vodmgr.getBroadcasts(vod._id)
                 isVod = true
+                root.curVodId = vod._id
 
                 duration = vod.duration
 
                 console.log("Setting up VOD, duration " + vod.duration)
 
-                seekBar.setPosition(0, duration)
+                seekBar.setPosition(startPos, duration)
             }
         } else {
             isVod = false;
@@ -222,7 +224,7 @@ Item {
             } else {
                 var vodIdNum = parseInt(vod._id.substring(1));
                 console.log("replaying chat for vod", vodIdNum, "starting at", startEpochTime);
-                chatview.replayChat(currentChannel.name, currentChannel._id, vodIdNum, startEpochTime);
+                chatview.replayChat(currentChannel.name, currentChannel._id, vodIdNum, startEpochTime, startPos);
             }
         } else {
             chatview.joinChannel(currentChannel.name, currentChannel._id);
@@ -307,7 +309,10 @@ Item {
 
         onPositionChanged: {
             chatview.playerPositionUpdate(renderer.position);
-            seekBar.setPosition(renderer.position, duration)
+            if (root.isVod) {
+                g_cman.setVodLastPlaybackPosition(root.currentChannel.name, root.curVodId, renderer.position);
+            }
+            seekBar.setPosition(renderer.position, duration);
         }
 
         onPlayingResumed: {

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -30,6 +30,7 @@ Item {
     property bool isVod: false
     property bool streamOnline: true
     property string curVodId
+    property int lastSetPosition
 
     property bool cursorHidden: false
     property string currentQualityName
@@ -187,6 +188,7 @@ Item {
                 g_vodmgr.getBroadcasts(vod._id)
                 isVod = true
                 root.curVodId = vod._id
+                root.lastSetPosition = startPos
 
                 duration = vod.duration
 
@@ -308,11 +310,15 @@ Item {
         }
 
         onPositionChanged: {
-            chatview.playerPositionUpdate(renderer.position);
+            var newPos = renderer.position;
+            chatview.playerPositionUpdate(newPos);
             if (root.isVod) {
-                g_cman.setVodLastPlaybackPosition(root.currentChannel.name, root.curVodId, renderer.position);
+                if (Math.abs(newPos - root.lastSetPosition) > 10) {
+                    root.lastSetPosition = newPos;
+                    g_cman.setVodLastPlaybackPosition(root.currentChannel.name, root.curVodId, newPos);
+                }
             }
-            seekBar.setPosition(renderer.position, duration);
+            seekBar.setPosition(newPos, duration);
         }
 
         onPlayingResumed: {

--- a/src/qml/VodsView.qml
+++ b/src/qml/VodsView.qml
@@ -85,12 +85,28 @@ Item{
         }
 
         onItemClicked: {
-            playerView.getStreams(selectedChannel, clickedItem)
+            var lastPlaybackPosition = vods.getLastPlaybackPosition(selectedChannel, clickedItem);
+            playerView.getStreams(selectedChannel, clickedItem, lastPlaybackPosition == null? 0 : lastPlaybackPosition);
+        }
+
+        function getLastPlaybackPosition(channel, vod) {
+            console.log("getLastPlaybackPosition", channel.name, vod._id);
+            return g_cman.getVodLastPlaybackPosition(channel.name, vod._id);
         }
 
         onItemRightClicked: {
             _menu.item = clickedItem
-            _menu.popup()
+
+            var lastPlayed = getLastPlaybackPosition(selectedChannel, clickedItem);
+            var haveLastPlayTime = lastPlayed != null;
+            _furthestPlayedMenuItem.enabled = haveLastPlayTime;
+            if (haveLastPlayTime) {
+               _furthestPlayedMenuItem.text = "Watch video from " + Util.getTime(lastPlayed);
+            } else {
+               _furthestPlayedMenuItem.text = "Watch video from furthest played";
+            }
+
+            _menu.popup();
         }
 
         onItemTooltipHover: {
@@ -114,10 +130,17 @@ Item{
         ContextMenu {
             id: _menu
             MenuItem {
-                text: "Watch video"
+                text: "Watch video from start"
                 //text: "Watch;play"
                 onTriggered: {
-                    playerView.getStreams(selectedChannel, _menu.item)
+                    playerView.getStreams(selectedChannel, _menu.item, 0)
+                }
+            }
+
+            MenuItem {
+                id: _furthestPlayedMenuItem
+                onTriggered: {
+                    playerView.getStreams(selectedChannel, _menu.item, vods.getLastPlaybackPosition(selectedChannel, _menu.item))
                 }
             }
         }

--- a/src/qml/VodsView.qml
+++ b/src/qml/VodsView.qml
@@ -18,9 +18,12 @@ import "components"
 import "util.js" as Util
 
 Item{
+    id: vodsView
+
     anchors.fill: parent
     property variant selectedChannel
     property int itemCount: 0
+    property var channelVodPositions
 
     function search(channel){
 
@@ -41,6 +44,8 @@ Item{
 
         header.text = "Videos for " + selectedChannel.title;
 
+        channelVodPositions = g_cman.getChannelVodsLastPlaybackPositions(channel.name);
+
         g_vodmgr.search(selectedChannel._id, 0, 35)
 
         itemCount = 35
@@ -58,6 +63,18 @@ Item{
         if (visible) {
             vods.positionViewAtBeginning()
             vods.checkScroll()
+        }
+    }
+
+    Connections {
+        target: g_cman
+        onVodLastPositionUpdated: {
+            //console.log("onVodLastPositionUpdated", channel, vod, position);
+            if (selectedChannel.name == channel) {
+                channelVodPositions[vod] = position;
+                // need binding to update
+                channelVodPositions = channelVodPositions;
+            }
         }
     }
 
@@ -80,6 +97,7 @@ Item{
             views: model.views
             preview: model.preview
             duration: model.duration
+            position: channelVodPositions[model.id] || 0
             game: model.game
             createdAt: model.createdAt
         }

--- a/src/qml/components/Video.qml
+++ b/src/qml/components/Video.qml
@@ -20,6 +20,7 @@ Rectangle {
     property string title
     property string preview
     property int views
+    property int position
     property int duration
     property string game
     property string createdAt
@@ -87,6 +88,16 @@ Rectangle {
             anchors {
                 left: container.left
                 right: container.right
+                bottom: container.bottom
+            }
+        }
+
+        Rectangle {
+            height: infoRect.height
+            width: container.width * root.position / root.duration
+            color: Styles.purple
+            anchors {
+                left: container.left
                 bottom: container.bottom
             }
         }

--- a/src/qml/irc/Chat.qml
+++ b/src/qml/irc/Chat.qml
@@ -86,8 +86,8 @@ Item {
         messageReceived("notice", null, "", false, false, false, [], true, "Joined channel #" + channelName, false)
     }
 
-    function replayChat(channelName, channelId, vodId, startEpochTime) {
-        chat.replay(channelName, channelId, vodId, startEpochTime, 0)
+    function replayChat(channelName, channelId, vodId, startEpochTime, startPos) {
+        chat.replay(channelName, channelId, vodId, startEpochTime, startPos)
         enterChannelCommon(channelName, channelId);
         root.replayMode = true
         messageReceived("notice", null, "", false, false, false, [], true, "Starting chat replay #" + channelName + " v" + vodId, false)

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -79,11 +79,11 @@ Item {
         chat.leaveChannel()
     }
 
-    function replayChat(channelName, channelId, vodId, startEpochTime) {
+    function replayChat(channelName, channelId, vodId, startEpochTime, startPos) {
         viewerListEnabled = false;
         cleanupPrevChannel()
         chat.leaveChannel()
-        chat.replayChat(channelName, channelId, vodId, startEpochTime);
+        chat.replayChat(channelName, channelId, vodId, startEpochTime, startPos);
     }
 
     function playerSeek(newOffset) {


### PR DESCRIPTION
Track last playback positions of VODs, and save them in the local settings. When playing a VOD, default to the saved position if there is one, but allow starting at the beginning through the context menu.  Implements https://github.com/alamminsalo/orion/issues/121.