### PR TITLE
Build Windows installer on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,7 +78,8 @@ build_script:
 after_build:
   - 7z a orion_%configuration%_%platform%_snapshot.zip . -x!.git
   - copy /y %MPVDIR%\mpv-dev.7z .
-  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /F"Orion-1.x-%platform%-%APPVEYOR_REPO_COMMIT%" "resources\orion-installer.iss"
+  - if %configuration%==release copy "resources\orion-installer.iss" orion-installer.iss
+  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /F"Orion-1.x-%platform%-%APPVEYOR_REPO_COMMIT%" "orion-installer.iss"
 
 artifacts:
   - path: orion_$(configuration)_$(platform)_snapshot.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,6 +80,7 @@ after_build:
   - copy /y %MPVDIR%\mpv-dev.7z .
   - del %configuration%\*.obj
   - del %configuration%\*.cpp
+  - del %configuration%\*.h
   - del %configuration%\*.res
   - if %configuration%==release copy "resources\orion-installer.iss" orion-installer.iss
   - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /F"orion-%APPVEYOR_REPO_COMMIT%-%platform%" "orion-installer.iss"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+# For info about dev tool paths on Appveyor see https://www.appveyor.com/docs/build-environment/#pre-installed-software
+
 environment:
   matrix:
     - platform: x86
@@ -76,9 +78,12 @@ build_script:
 after_build:
   - 7z a orion_%configuration%_%platform%_snapshot.zip . -x!.git
   - copy /y %MPVDIR%\mpv-dev.7z .
+  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /F"Orion-1.x-%platform%-%APPVEYOR_REPO_COMMIT%" "resources\orion-installer.iss"
 
 artifacts:
   - path: orion_$(configuration)_$(platform)_snapshot.zip
     name: orion windows $(configuration) $(platform) snapshot zip
   - path: mpv-dev.7z
     name: libmpv dev archive used for build
+  - path: Orion-1.x-$(platform)-$(APPVEYOR_REPO_COMMIT).exe
+    name: Windows installer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,18 +76,18 @@ build_script:
     dir /s
 
 after_build:
-  - 7z a orion_%configuration%_%platform%_snapshot.zip . -x!.git
+  - 7z a orion_%configuration%_%platform%_snapshot_%APPVEYOR_REPO_COMMIT%.zip . -x!.git
   - copy /y %MPVDIR%\mpv-dev.7z .
   - del %configuration%\*.obj
   - del %configuration%\*.cpp
   - del %configuration%\*.res
   - if %configuration%==release copy "resources\orion-installer.iss" orion-installer.iss
-  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /F"Orion-1.x-%platform%-%APPVEYOR_REPO_COMMIT%" "orion-installer.iss"
+  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /F"orion-%APPVEYOR_REPO_COMMIT%-%platform%" "orion-installer.iss"
 
 artifacts:
-  - path: orion_$(configuration)_$(platform)_snapshot.zip
+  - path: orion_$(configuration)_$(platform)_snapshot_$(APPVEYOR_REPO_COMMIT).zip
     name: orion windows $(configuration) $(platform) snapshot zip
   - path: mpv-dev.7z
     name: libmpv dev archive used for build
-  - path: Orion-1.x-$(platform)-$(APPVEYOR_REPO_COMMIT).exe
+  - path: orion-$(APPVEYOR_REPO_COMMIT-$(platform).exe
     name: Windows installer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,5 +89,5 @@ artifacts:
     name: orion windows $(configuration) $(platform) snapshot zip
   - path: mpv-dev.7z
     name: libmpv dev archive used for build
-  - path: orion-$(APPVEYOR_REPO_COMMIT-$(platform).exe
+  - path: orion-$(APPVEYOR_REPO_COMMIT)-$(platform).exe
     name: Windows installer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,6 +78,9 @@ build_script:
 after_build:
   - 7z a orion_%configuration%_%platform%_snapshot.zip . -x!.git
   - copy /y %MPVDIR%\mpv-dev.7z .
+  - del %configuration%\*.obj
+  - del %configuration%\*.cpp
+  - del %configuration%\*.res
   - if %configuration%==release copy "resources\orion-installer.iss" orion-installer.iss
   - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /F"Orion-1.x-%platform%-%APPVEYOR_REPO_COMMIT%" "orion-installer.iss"
 

--- a/resources/orion-installer.iss
+++ b/resources/orion-installer.iss
@@ -3,9 +3,11 @@
 
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING .ISS SCRIPT FILES!
 
+#define AppVersion GetFileVersion("release\orion.exe")
+
 [Setup]
 AppName=Orion
-AppVersion=1.0
+AppVersion={#AppVersion}
 DefaultDirName={pf}\Orion
 DefaultGroupName=Orion
 UninstallDisplayIcon={app}\orion.exe


### PR DESCRIPTION
- Add Inno Setup installer build to AppVeyor
- Set installer version based on built orion.exe file version
- Put git commit ID in built snapshot and installer filenames

Re: https://github.com/alamminsalo/orion/issues/180