### PR TITLE
What I needed to do to build on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ qmake ../
 make && sudo make install
 ```
 
+## Building on MacOS
+
+#### Install needed libraries and software
+
+```
+brew install qt mpv
+```
+
+#### Get orion from github and install
+
+```
+git clone https://github.com/alamminsalo/orion
+cd orion
+mkdir build && cd build
+qmake ../
+make
+```
+
+There will now be an orion.app application in the build directory.
+
+
 ## Windows troubleshooting
 
 You need Visual C++ 2015-runtime installed. 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ make && sudo make install
 
 ```
 brew install qt mpv
+brew link --force qt
 ```
+You need to force link qt to get qmake. Note that this can cause problems with other make tools. For more information see `brew info qt`.
 
 #### Get orion from github and install
 

--- a/orion.pro
+++ b/orion.pro
@@ -73,7 +73,7 @@ mpv {
 
     unix:!macx: LIBS += -lmpv
     win32: LIBS += -L$$PWD/libs -lmpv
-    macx: LIBS += -L$$PWD/../../../../usr/local/Cellar/mpv/0.17.0/lib -lmpv
+    macx: LIBS += -L$$PWD/../../../../usr/local/Cellar/mpv/0.25.0/lib -lmpv
 }
 
 qtav {
@@ -171,6 +171,7 @@ macx: {
 
     INCLUDEPATH += /System/Library/Frameworks/Foundation.framework/Versions/C/Headers
     INCLUDEPATH += /System/Library/Frameworks/AppKit.framework/Versions/C/Headers
+    INCLUDEPATH += /usr/local/include
 }
 
 OBJECTIVE_SOURCES += \


### PR DESCRIPTION
You may not want to merge this, but this is what I did to get Orion building on the ol' Apple. This may be relevant to #180.

I'm not really familiar with make or anything like that. Not sure if there is a better way than hard-coding the `mpv` version, but it was originally like that so I just updated it for what is currently on brew.