### PR TITLE
Travis Mac build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,12 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
   - bash distfiles/deploy_mac.sh
+  - if [ -n "TRAVIS_TAG" ]; then zip -vr orion.app.zip orion.app/; fi
+  
+deploy:
+  provider: releases
+  api_key: '$GITHUB_API_KEY'
+  file: 'orion.app.zip'
+  skip_cleanup: true
+  on:
+    tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,16 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
+  - if [ -d orion.app ]; rm -rf orion.app; fi
   - bash distfiles/deploy_mac.sh
-  - if [ -n "TRAVIS_TAG" ]; then zip -vr orion.app.zip orion.app/; fi
+  - mkdir -p artifacts
+  - zip -vr artifacts/orion.app.zip orion.app/
   
 deploy:
   - provider: releases
     # To use this, create a Github token with the "public_repo" permission, and create an env var GITHUB_API_KEY in the Travis' project settings' environment, making sure "Display value in build log" is set to OFF
     api_key: '$GITHUB_API_KEY'
-    file: 'orion.app.zip'
+    file: 'artifacts/orion.app.zip'
     skip_cleanup: true
     on:
       tags: true
@@ -48,7 +50,7 @@ deploy:
     #         }
     #     ]
     # }	
-    file: 'orion.app.zip'
+    local_dir: artifacts
     skip_cleanup: true
     on:
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
 
 script:
-  - cd src
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro; fi
   - make
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - osx
   
 env:
-  - QTVER=5.9
+  - QTVER=5.9.0
   
 language: cpp
   
@@ -14,8 +14,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
 
 script:
+  - set QMAKE=qmake
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then set QMAKE=/usr/local/Cellar/qt/$QTVER/bin/qmake; fi
   - cd src
-  - qmake orion.pro
+  - $QMAKE orion.pro
   - make
   - cd ..
   - bash distfiles/deploy_mac.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   
 env:
   - QTVER=5.9.0
-  - QTBREWVER=5.9
+    QTBREWVER=5.9
   
 language: cpp
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,11 @@ cache:
     - $HOME/Library/Caches/Homebrew
 
 before_install:
-#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTBREWVER; fi
-  - brew info --json=v1 qt
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTBREWVER jq; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
+  - export QTDIR=$(brew info --json=v1 qt | jq 'map(.bottle.stable.cellar + "/" + .name + "/" + .installed[0].version)')
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $QTDIR/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
   - bash distfiles/deploy_mac.sh
   - mkdir -p artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,4 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
-  - cd ..
   - bash distfiles/deploy_mac.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,18 +37,17 @@ deploy:
     secret_access_key: "$AWS_SECRET_ACCESS_KEY"
     bucket: "$AWS_S3_BUCKET"
     region: "$AWS_REGION"
-	
-# Example policy to allow writes to bucket
-# {
-    # "Version": "2012-10-17",
-    # "Statement": [
-        # {
-            # "Effect": "Allow",
-            # "Action": "s3:PutObject",
-            # "Resource": "arn:aws:s3:::rakslice-orion-builds/*"
-        # }
-    # ]
-# }	
+    # Example policy to allow writes to bucket
+    # {
+    #     "Version": "2012-10-17",
+    #     "Statement": [
+    #         {
+    #             "Effect": "Allow",
+    #             "Action": "s3:PutObject",
+    #             "Resource": "arn:aws:s3:::rakslice-orion-builds/*"
+    #         }
+    #     ]
+    # }	
     file: 'orion.app.zip'
     skip_cleanup: true
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
-  - cd distfiles && bash deploy_mac.sh ; cd ..
+  - bash distfiles/deploy_mac.sh
   - mkdir -p artifacts
   - zip -vr artifacts/orion.app.zip orion.app/
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ cache:
 
 before_install:
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt mpv; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
   - cd ..
   - bash distfiles/deploy_mac.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
-  - if [ -d orion.app ]; rm -rf orion.app; fi
+  - if [ -d orion.app ]; then rm -rf orion.app; fi
   - bash distfiles/deploy_mac.sh
   - mkdir -p artifacts
   - zip -vr artifacts/orion.app.zip orion.app/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ language: cpp
   
 compiler:
   - clang
+  
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTBREWVER jq; fi
 
 script:
-  - export QTDIR=$(brew info --json=v1 qt | jq 'map(.bottle.stable.cellar + "/" + .name + "/" + .installed[0].version)')
+  - export QTDIR=$(brew info --json=v1 qt | jq '.[0].bottle.stable.cellar + "/" + .[0].name + "/" + .[0].installed[0].version')
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $QTDIR/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
   - bash distfiles/deploy_mac.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+os:
+  - osx
+  
+env:
+  - QTVER=5.9
+  
+compiler:
+  - clang
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
+
+script:
+  - cd src
+  - qmake orion.pro
+  - make
+  - cd ..
+  - bash distfiles/deploy_mac.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 
 before_install:
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTVER; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - make
   - bash distfiles/deploy_mac.sh
   - mkdir -p artifacts
-  - zip -vr artifacts/orion.app.zip orion.app/
+  - zip -vr --symlinks artifacts/orion.app.zip orion.app/
   
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 
 before_install:
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt mpv; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,26 +26,28 @@ script:
   
 deploy:
   - provider: releases
-    # To use this, create a Github token with the "public_repo" permission, and create an env var GITHUB_API_KEY in the Travis' project settings' environment, making sure "Display value in build log" is set to OFF
+    # To use this, create a Github token with the "public_repo" permission, and create an env var GITHUB_API_KEY in the Travis' project settings, making sure "Display value in build log" is set to OFF
     api_key: '$GITHUB_API_KEY'
     file: 'artifacts/orion.app.zip'
     skip_cleanup: true
     on:
       tags: true
       all_branches: true
+    # To use this, create an AWS S3 bucket with public read access, create IAM policy with the text below replacing the placeholder with the bucket name, 
+    # create an AWS user for automation (with access key/secret) and give them that IAM policy, and set the env vars indicated in the Travis' project settings, making sure "Display value in build log" is set to OFF
   - provider: s3
     access_key_id: "$AWS_ACCESS_KEY_ID"
     secret_access_key: "$AWS_SECRET_ACCESS_KEY"
     bucket: "$AWS_S3_BUCKET"
     region: "$AWS_REGION"
-    # Example policy to allow writes to bucket
+    # Example policy to allow writes to a bucket
     # {
     #     "Version": "2012-10-17",
     #     "Statement": [
     #         {
     #             "Effect": "Allow",
     #             "Action": "s3:PutObject",
-    #             "Resource": "arn:aws:s3:::rakslice-orion-builds/*"
+    #             "Resource": "arn:aws:s3:::BUCKET-NAME-GOES-HERE/*"
     #         }
     #     ]
     # }	

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export QTDIR=$(brew info --json=v1 qt | jq -r '.[0].bottle.stable.cellar + "/" + .[0].name + "/" + .[0].installed[0].version'); fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export ORIONCONFIG=multimedia; fi
-  - $QTDIR/bin/qmake orion.pro CONFIG+=$(ORIONCONFIG)
+  - $QTDIR/bin/qmake orion.pro CONFIG+=$ORIONCONFIG
   - make
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash distfiles/deploy_mac.sh; fi
   - mkdir -p artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTBREWVER jq; fi
 
 script:
-  - export QTDIR=$(brew info --json=v1 qt | jq '.[0].bottle.stable.cellar + "/" + .[0].name + "/" + .[0].installed[0].version')
+  - export QTDIR=$(brew info --json=v1 qt | jq -r '.[0].bottle.stable.cellar + "/" + .[0].name + "/" + .[0].installed[0].version')
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $QTDIR/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
   - bash distfiles/deploy_mac.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ os:
   - osx
   
 env:
-  - QTVER=5.9.0
-    QTBREWVER=5.9
+  - QTBREWVER=5.9
   
 language: cpp
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   
 deploy:
   provider: releases
+  # To use this, create a Github token with the "public_repo" permission, and create an env var GITHUB_API_KEY in the Travis' project settings' environment, making sure "Display value in build log" is set to OFF
   api_key: '$GITHUB_API_KEY'
   file: 'orion.app.zip'
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
-  - if [ -d orion.app ]; then rm -rf orion.app; fi
   - bash distfiles/deploy_mac.sh
   - mkdir -p artifacts
   - zip -vr artifacts/orion.app.zip orion.app/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   
 env:
   - QTVER=5.9.0
+  - QTBREWVER=5.9
   
 language: cpp
   
@@ -15,7 +16,8 @@ cache:
 
 before_install:
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTVER; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTBREWVER; fi
+  - brew info --json=v1 qt
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTBREWVER jq; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $(brew info --json=v1 qt | jq 'map(.bottle.stable.cellar + "/" + .name + "/" + .installed[0].version)')/bin/qmake orion.pro CONFIG+=multimedia; fi
+  - export QTDIR=$(brew info --json=v1 qt | jq 'map(.bottle.stable.cellar + "/" + .name + "/" + .installed[0].version)')
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $QTDIR/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
-  - QTDIR=$(brew info --json=v1 qt | jq 'map(.bottle.stable.cellar + "/" + .name + "/" + .installed[0].version)') bash distfiles/deploy_mac.sh
+  - bash distfiles/deploy_mac.sh
   - mkdir -p artifacts
   - zip -vr artifacts/orion.app.zip orion.app/
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
 env:
   - QTVER=5.9
   
+language: cpp
+  
 compiler:
   - clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTBREWVER jq; fi
 
 script:
-  - export QTDIR=$(brew info --json=v1 qt | jq -r '.[0].bottle.stable.cellar + "/" + .[0].name + "/" + .[0].installed[0].version')
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $QTDIR/bin/qmake orion.pro CONFIG+=multimedia; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export QTDIR=$(brew info --json=v1 qt | jq -r '.[0].bottle.stable.cellar + "/" + .[0].name + "/" + .[0].installed[0].version'); fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export ORIONCONFIG=multimedia; fi
+  - $QTDIR/bin/qmake orion.pro CONFIG+=$(ORIONCONFIG)
   - make
-  - bash distfiles/deploy_mac.sh
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash distfiles/deploy_mac.sh; fi
   - mkdir -p artifacts
-  - zip -vr --symlinks artifacts/orion.app.zip orion.app/
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then zip -vr --symlinks artifacts/orion.app.zip orion.app/; fi
   
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - $HOME/Library/Caches/Homebrew
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,32 @@ script:
   - if [ -n "TRAVIS_TAG" ]; then zip -vr orion.app.zip orion.app/; fi
   
 deploy:
-  provider: releases
-  # To use this, create a Github token with the "public_repo" permission, and create an env var GITHUB_API_KEY in the Travis' project settings' environment, making sure "Display value in build log" is set to OFF
-  api_key: '$GITHUB_API_KEY'
-  file: 'orion.app.zip'
-  skip_cleanup: true
-  on:
-    tags
+  - provider: releases
+    # To use this, create a Github token with the "public_repo" permission, and create an env var GITHUB_API_KEY in the Travis' project settings' environment, making sure "Display value in build log" is set to OFF
+    api_key: '$GITHUB_API_KEY'
+    file: 'orion.app.zip'
+    skip_cleanup: true
+    on:
+      tags: true
+      all_branches: true
+  - provider: s3
+    access_key_id: "$AWS_ACCESS_KEY_ID"
+    secret_access_key: "$AWS_SECRET_ACCESS_KEY"
+    bucket: "$AWS_S3_BUCKET"
+    region: "$AWS_REGION"
+	
+# Example policy to allow writes to bucket
+# {
+    # "Version": "2012-10-17",
+    # "Statement": [
+        # {
+            # "Effect": "Allow",
+            # "Action": "s3:PutObject",
+            # "Resource": "arn:aws:s3:::rakslice-orion-builds/*"
+        # }
+    # ]
+# }	
+    file: 'orion.app.zip'
+    skip_cleanup: true
+    on:
+      all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
-  - bash distfiles/deploy_mac.sh
+  - cd distfiles && bash deploy_mac.sh ; cd ..
   - mkdir -p artifacts
   - zip -vr artifacts/orion.app.zip orion.app/
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,9 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt@$QTBREWVER jq; fi
 
 script:
-  - export QTDIR=$(brew info --json=v1 qt | jq 'map(.bottle.stable.cellar + "/" + .name + "/" + .installed[0].version)')
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $QTDIR/bin/qmake orion.pro CONFIG+=multimedia; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $(brew info --json=v1 qt | jq 'map(.bottle.stable.cellar + "/" + .name + "/" + .installed[0].version)')/bin/qmake orion.pro CONFIG+=multimedia; fi
   - make
-  - bash distfiles/deploy_mac.sh
+  - QTDIR=$(brew info --json=v1 qt | jq 'map(.bottle.stable.cellar + "/" + .name + "/" + .installed[0].version)') bash distfiles/deploy_mac.sh
   - mkdir -p artifacts
   - zip -vr artifacts/orion.app.zip orion.app/
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
 
 script:
-  - set QMAKE=qmake
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then set QMAKE=/usr/local/Cellar/qt/$QTVER/bin/qmake; fi
   - cd src
-  - $QMAKE orion.pro
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then /usr/local/Cellar/qt/$QTVER/bin/qmake orion.pro; fi
   - make
   - cd ..
   - bash distfiles/deploy_mac.sh

--- a/distfiles/deploy_mac.sh
+++ b/distfiles/deploy_mac.sh
@@ -17,5 +17,5 @@ cp -r $QTDIR/qml/QtQuick orion.app/Contents/Resources/qml
 cp -r $QTDIR/qml/QtQuick.2 orion.app/Contents/Resources/qml
 #cp -r $QTDIR/qml/Communi orion.app/Contents/Resources/qml
 
-#sh fixlibs.sh orion.app
+sh fixlibs.sh orion.app
 

--- a/distfiles/deploy_mac.sh
+++ b/distfiles/deploy_mac.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 set -e -x
 
-QTVER=5.9
+QTVER=5.9.0
+
+QTDIR=/usr/local/Cellar/qt/$QTVER
 
 # macdeploy
-~/Qt/$QTVER/clang_64/bin/macdeployqt orion.app -qmldir=~/git/orion/src/qml
+$QTDIR/clang_64/bin/macdeployqt orion.app -qmldir=~/git/orion/src/qml
 
 # qml libs 
 mkdir orion.app/Contents/Resources/qml
-#cp -r ~/Qt/$QTVER/clang_64/qml/Enginio orion.app/Contents/Resources/qml
-cp -r ~/Qt/$QTVER/clang_64/qml/Qt orion.app/Contents/Resources/qml
-cp -r ~/Qt/$QTVER/clang_64/qml/QtQml orion.app/Contents/Resources/qml
-cp -r ~/Qt/$QTVER/clang_64/qml/QtQuick orion.app/Contents/Resources/qml
-cp -r ~/Qt/$QTVER/clang_64/qml/QtQuick.2 orion.app/Contents/Resources/qml
-#cp -r ~/Qt/$QTVER/clang_64/qml/Communi orion.app/Contents/Resources/qml
+#cp -r $QTDIR/clang_64/qml/Enginio orion.app/Contents/Resources/qml
+cp -r $QTDIR/clang_64/qml/Qt orion.app/Contents/Resources/qml
+cp -r $QTDIR/clang_64/qml/QtQml orion.app/Contents/Resources/qml
+cp -r $QTDIR/clang_64/qml/QtQuick orion.app/Contents/Resources/qml
+cp -r $QTDIR/clang_64/qml/QtQuick.2 orion.app/Contents/Resources/qml
+#cp -r $QTDIR/clang_64/qml/Communi orion.app/Contents/Resources/qml
 
 #sh fixlibs.sh orion.app
 

--- a/distfiles/deploy_mac.sh
+++ b/distfiles/deploy_mac.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e -x
 
-QTVER=5.9.0
-
-QTDIR=/usr/local/Cellar/qt/$QTVER
-
 # macdeploy
 $QTDIR/bin/macdeployqt orion.app -qmldir=./src/qml
 

--- a/distfiles/deploy_mac.sh
+++ b/distfiles/deploy_mac.sh
@@ -17,5 +17,5 @@ cp -r $QTDIR/qml/QtQuick orion.app/Contents/Resources/qml
 cp -r $QTDIR/qml/QtQuick.2 orion.app/Contents/Resources/qml
 #cp -r $QTDIR/qml/Communi orion.app/Contents/Resources/qml
 
-sh fixlibs.sh orion.app
+sh distfiles/fixlibs.sh orion.app
 

--- a/distfiles/deploy_mac.sh
+++ b/distfiles/deploy_mac.sh
@@ -6,12 +6,10 @@ $QTDIR/bin/macdeployqt orion.app -qmldir=./src/qml
 
 # qml libs 
 mkdir -p orion.app/Contents/Resources/qml
-#cp -r $QTDIR/qml/Enginio orion.app/Contents/Resources/qml
 cp -r $QTDIR/qml/Qt orion.app/Contents/Resources/qml
 cp -r $QTDIR/qml/QtQml orion.app/Contents/Resources/qml
 cp -r $QTDIR/qml/QtQuick orion.app/Contents/Resources/qml
 cp -r $QTDIR/qml/QtQuick.2 orion.app/Contents/Resources/qml
-#cp -r $QTDIR/qml/Communi orion.app/Contents/Resources/qml
 
 sh distfiles/fixlibs.sh orion.app
 

--- a/distfiles/deploy_mac.sh
+++ b/distfiles/deploy_mac.sh
@@ -6,16 +6,16 @@ QTVER=5.9.0
 QTDIR=/usr/local/Cellar/qt/$QTVER
 
 # macdeploy
-$QTDIR/clang_64/bin/macdeployqt orion.app -qmldir=~/git/orion/src/qml
+$QTDIR/bin/macdeployqt orion.app -qmldir=./src/qml
 
 # qml libs 
 mkdir orion.app/Contents/Resources/qml
-#cp -r $QTDIR/clang_64/qml/Enginio orion.app/Contents/Resources/qml
-cp -r $QTDIR/clang_64/qml/Qt orion.app/Contents/Resources/qml
-cp -r $QTDIR/clang_64/qml/QtQml orion.app/Contents/Resources/qml
-cp -r $QTDIR/clang_64/qml/QtQuick orion.app/Contents/Resources/qml
-cp -r $QTDIR/clang_64/qml/QtQuick.2 orion.app/Contents/Resources/qml
-#cp -r $QTDIR/clang_64/qml/Communi orion.app/Contents/Resources/qml
+#cp -r $QTDIR/qml/Enginio orion.app/Contents/Resources/qml
+cp -r $QTDIR/qml/Qt orion.app/Contents/Resources/qml
+cp -r $QTDIR/qml/QtQml orion.app/Contents/Resources/qml
+cp -r $QTDIR/qml/QtQuick orion.app/Contents/Resources/qml
+cp -r $QTDIR/qml/QtQuick.2 orion.app/Contents/Resources/qml
+#cp -r $QTDIR/qml/Communi orion.app/Contents/Resources/qml
 
 #sh fixlibs.sh orion.app
 

--- a/distfiles/deploy_mac.sh
+++ b/distfiles/deploy_mac.sh
@@ -1,24 +1,19 @@
 #!/bin/bash
+set -e -x
 
-QTVER=5.5
+QTVER=5.9
 
 # macdeploy
 ~/Qt/$QTVER/clang_64/bin/macdeployqt orion.app -qmldir=~/git/orion/src/qml
 
 # qml libs 
 mkdir orion.app/Contents/Resources/qml
-cp -r ~/Qt/$QTVER/clang_64/qml/Enginio orion.app/Contents/Resources/qml
+#cp -r ~/Qt/$QTVER/clang_64/qml/Enginio orion.app/Contents/Resources/qml
 cp -r ~/Qt/$QTVER/clang_64/qml/Qt orion.app/Contents/Resources/qml
 cp -r ~/Qt/$QTVER/clang_64/qml/QtQml orion.app/Contents/Resources/qml
 cp -r ~/Qt/$QTVER/clang_64/qml/QtQuick orion.app/Contents/Resources/qml
 cp -r ~/Qt/$QTVER/clang_64/qml/QtQuick.2 orion.app/Contents/Resources/qml
-cp -r ~/Qt/$QTVER/clang_64/qml/QtWebEngine orion.app/Contents/Resources/qml
-cp -r ~/Qt/$QTVER/clang_64/qml/Communi orion.app/Contents/Resources/qml
+#cp -r ~/Qt/$QTVER/clang_64/qml/Communi orion.app/Contents/Resources/qml
 
-# additional frameworks
-cp -r ~/Qt/$QTVER/clang_64/lib/IrcCore.framework orion.app/Contents/Frameworks/IrcCore.framework
-cp -r ~/Qt/$QTVER/clang_64/lib/IrcModel.framework orion.app/Contents/Frameworks/IrcModel.framework
-cp -r ~/Qt/$QTVER/clang_64/lib/IrcUtil.framework orion.app/Contents/Frameworks/IrcUtil.framework
-
-sh fixlibs.sh orion.app
+#sh fixlibs.sh orion.app
 

--- a/distfiles/deploy_mac.sh
+++ b/distfiles/deploy_mac.sh
@@ -9,7 +9,7 @@ QTDIR=/usr/local/Cellar/qt/$QTVER
 $QTDIR/bin/macdeployqt orion.app -qmldir=./src/qml
 
 # qml libs 
-mkdir orion.app/Contents/Resources/qml
+mkdir -p orion.app/Contents/Resources/qml
 #cp -r $QTDIR/qml/Enginio orion.app/Contents/Resources/qml
 cp -r $QTDIR/qml/Qt orion.app/Contents/Resources/qml
 cp -r $QTDIR/qml/QtQml orion.app/Contents/Resources/qml

--- a/distfiles/fixlibs.sh
+++ b/distfiles/fixlibs.sh
@@ -7,8 +7,10 @@ DIR=$1
 FRAMEWORKS="QtOpenGL QtWidgets QtGui QtCore QtQuick QtQml QtNetwork QtMultimedia"
 
 echo "Fixing lib paths..."
+
+echo "- orion"
 for FRAMEWORK in $FRAMEWORKS; do
-	echo $FRAMEWORK
+	echo "  $FRAMEWORK"
 	install_name_tool -id @executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	$DIR/Contents/Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK
 
@@ -21,25 +23,31 @@ for FRAMEWORK in $FRAMEWORKS; do
 	$DIR/Contents/MacOS/orion
 done
 
-#QtQuick.2 dylib
-FRAMEWORKS="QtQuick QtQml QtNetwork QtCore QtGui"
+for ref in Resources/qml/{QtQuick/{Window.2/libwindow,Controls/libqtquickcontrols,Controls/Styles/Flat/libqtquickextrasflat,Controls.2/{libqtquickcontrols2,Material/libqtquickcontrols2materialstyle,Universal/libqtquickcontrols2universalstyle},Dialogs/{libdialog,Private/libdialogsprivate},Extras/libqtquickextras,LocalStorage/libqmllocalstorage,Particles.2/libparticles,PrivateWidgets/libwidgets,Scene2D/libqtquickscene2d,Scene3D/libqtquickscene3d,VirtualKeyboard/Styles/libqtvirtualkeyboardstyles,XmlListModel/libqmlxmllistmodel,Templates.2/libqtquicktemplates2,Layouts/libqquicklayouts},QtQuick.2/libqtquick2,Qt/labs/{calendar/libqtlabscalendar,folderlistmodel/libqmlfolderlistmodel,platform/libqtlabsplatform,settings/libqmlsettings,sharedimage/libsharedimage},QtQml/Models.2/libmodels}plugin.dylib PlugIns/quick/lib{models,qquicklayouts,qtquickcontrols2{material,universal}style,qtquickcontrols{,2},qtquickextrasflat,qtquicktemplates2,widgets,window}plugin.dylib Resources/qml/QtQml/StateMachine/libqtqmlstatemachine.dylib; do
+echo "- $ref"
+
+FRAMEWORKS="QtQuick QtQuickControls2 QtQuickTemplates2 QtQml QtNetwork QtCore QtGui QtWidgets"
 for FRAMEWORK in $FRAMEWORKS; do
-	echo $FRAMEWORK
+	echo "  $FRAMEWORK"
 	install_name_tool -id @executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	$DIR/Contents/Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK
 
 	install_name_tool -change @rpath/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
-	$DIR/Contents/Resources/qml/QtQuick.2/libqtquick2plugin.dylib
+	$DIR/Contents/$ref
 
 	install_name_tool -change $QTDIR/lib/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
-	$DIR/Contents/Resources/qml/QtQuick.2/libqtquick2plugin.dylib
+	$DIR/Contents/$ref
 done
+done
+
+echo "- multimedia"
 
 #Multimedia libs
 FRAMEWORKS="QtGui QtCore QtQuick QtQml QtNetwork QtMultimedia QtMultimediaQuick_p"
 for FRAMEWORK in $FRAMEWORKS; do
+	echo "  $FRAMEWORK"
 	install_name_tool -id @executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	$DIR/Contents/Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK
 

--- a/distfiles/fixlibs.sh
+++ b/distfiles/fixlibs.sh
@@ -4,7 +4,7 @@
 DIR=$1
 
 #Qt frameworks
-FRAMEWORKS="QtOpenGL QtWidgets QtGui QtCore QtWebEngine QtQuick QtQml QtNetwork QtMultimedia QtWebChannel QtWebEngineCore"
+FRAMEWORKS="QtOpenGL QtWidgets QtGui QtCore QtQuick QtQml QtNetwork QtMultimedia"
 
 echo "Fixing lib paths..."
 for FRAMEWORK in $FRAMEWORKS; do
@@ -27,18 +27,6 @@ for FRAMEWORK in $FRAMEWORKS; do
 	install_name_tool -change @rpath/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	$DIR/Contents/Resources/qml/QtQuick.2/libqtquick2plugin.dylib
-done
-
-#QtWebEngine
-FRAMEWORKS="QtWebEngine QtWebEngineCore QtQuick QtQml QtCore QtNetwork QtGui QtWebChannel"
-for FRAMEWORK in $FRAMEWORKS; do
-	echo $FRAMEWORK
-	install_name_tool -id @executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
-	$DIR/Contents/Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK
-
-	install_name_tool -change @rpath/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
-	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
-	$DIR/Contents/Resources/qml/QtWebEngine/libqtwebengineplugin.dylib
 done
 
 #Multimedia libs

--- a/distfiles/fixlibs.sh
+++ b/distfiles/fixlibs.sh
@@ -15,6 +15,10 @@ for FRAMEWORK in $FRAMEWORKS; do
 	install_name_tool -change @rpath/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	$DIR/Contents/MacOS/orion
+
+	install_name_tool -change $QTDIR/lib/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
+	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
+	$DIR/Contents/MacOS/orion
 done
 
 #QtQuick.2 dylib
@@ -27,6 +31,10 @@ for FRAMEWORK in $FRAMEWORKS; do
 	install_name_tool -change @rpath/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	$DIR/Contents/Resources/qml/QtQuick.2/libqtquick2plugin.dylib
+
+	install_name_tool -change $QTDIR/lib/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
+	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
+	$DIR/Contents/Resources/qml/QtQuick.2/libqtquick2plugin.dylib
 done
 
 #Multimedia libs
@@ -36,6 +44,10 @@ for FRAMEWORK in $FRAMEWORKS; do
 	$DIR/Contents/Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK
 
 	install_name_tool -change @rpath/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
+	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
+	$DIR/Contents/Resources/qml/QtMultimedia/libdeclarative_multimedia.dylib
+
+	install_name_tool -change $QTDIR/lib/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	@executable_path/../Frameworks/$FRAMEWORK.framework/Versions/5/$FRAMEWORK \
 	$DIR/Contents/Resources/qml/QtMultimedia/libdeclarative_multimedia.dylib
 done


### PR DESCRIPTION
Here's a Travis build config for Mac, and `deploy_mac.sh`/`fixlibs.sh` changes to go along with it.  Since Travis doesn't have its own artifact archiving, I've included `deploy` sections in `.travis.yml` for Amazon S3 and GitHub Releases (tags only), which you supply with credentials using Travis environment var settings.

Inline comments in `.travis.yml` explain what is necessary to set up on the GitHub and AWS sides.

This takes whatever most recent Qt 5.9 build is in homebrew.

This does a build that uses Qt Multimedia.

Both of these `deploy` sections have `all_branches` set for testing, but you can remove that to default to `master` only, or set other specific branch with `branch:` (see https://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on%3A)

It seems like `macdeployqt` is adding unnecessary plugins, although this does not seem to cause any functional problems.