### PR TITLE
win installer improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,7 @@ after_build:
   - del %configuration%\*.h
   - del %configuration%\*.res
   - if %configuration%==release copy "resources\orion-installer.iss" orion-installer.iss
-  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /F"orion-%APPVEYOR_REPO_COMMIT%-%platform%" "orion-installer.iss"
+  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /DPlatform=%platform% /DAdditionalRedist="C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\1033\vcredist_%platform%.exe" /F"orion-%APPVEYOR_REPO_COMMIT%-%platform%" "orion-installer.iss"
 
 artifacts:
   - path: orion_$(configuration)_$(platform)_snapshot_$(APPVEYOR_REPO_COMMIT).zip

--- a/resources/orion-installer.iss
+++ b/resources/orion-installer.iss
@@ -3,6 +3,16 @@
 
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING .ISS SCRIPT FILES!
 
+#ifndef Platform
+  #error Platform undefined. Pass /DPlatform={x86|x64}
+#endif
+
+#if "x86" == Platform
+#elif "x64" == Platform
+#else
+  #error Unknown platform. Must be x86 or x64
+#endif
+
 #define AppVersion GetFileVersion("release\orion.exe")
 
 [Setup]
@@ -14,9 +24,23 @@ UninstallDisplayIcon={app}\orion.exe
 Compression=lzma2
 SolidCompression=yes
 OutputDir=.
+#if "x64" == Platform
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+#endif
 
 [Files]
 Source: "release\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs
+#ifdef AdditionalRedist
+Source: "{#AdditionalRedist}"; DestDir: "{app}\AdditionalRedist"; Flags: ignoreversion
+#endif
 
 [Icons]
 Name: "{group}\Orion"; Filename: "{app}\bin\orion.exe"
+
+[Run]
+Filename: "{app}\bin\vcredist_{#Platform}.exe"; Parameters: "/install /passive /norestart"
+#ifdef AdditionalRedist
+#define AdditionalRedistProper ExtractFileName(AdditionalRedist)
+Filename: "{app}\AdditionalRedist\{#AdditionalRedistProper}"; Parameters: "/install /passive /norestart"
+#endif


### PR DESCRIPTION
Windows Inno Setup installer script improvements
- For the 64-bit version, require 64-bit and use 64-bit mode so that Orion is installed to `\Program Files` rather than `\Program Files (x86)`
- Run the Visual C++ redistributable installer selected by `windeployqt`
- Include and run an additional Visual C++ redistributable installer if specified

In AppVeyor builds, specify the Visual Studio 2013 (12.0) redistributable installer also as the provided OpenSSL libs require it.
