### PR TITLE
Don't show tray menu on startup.

### DIFF
--- a/src/qml/components/AppTray.qml
+++ b/src/qml/components/AppTray.qml
@@ -12,6 +12,8 @@ SystemTrayIcon {
 	property bool appVisible: rootWindow.visible
 
 	menu: Menu {
+		visible: false
+
 		MenuItem {
 			text: appVisible ? "Hide" : "Show"
 			onTriggered: {


### PR DESCRIPTION
Currently on orion startup besides orion main window an orion tray menu is shown in top left corner of screen while I think it should not. At least it shows up for me in linux/x11/kde5/qt-5.9.2. This small patch disables showing the tray menu on startup.