### PR TITLE
add hardware decoding options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main(int argc, char *argv[])
 
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
+    // Load app settings
+    SettingsManager::getInstance()->load();
 #ifndef Q_OS_ANDROID
     QApplication app(argc, argv);
 #else
@@ -97,13 +99,6 @@ int main(int argc, char *argv[])
     NetworkManager::initialize(engine.networkAccessManager());
 
 #ifndef Q_OS_ANDROID
-    //Single application solution
-    QLockFile lockfile(QDir::temp().absoluteFilePath("wz0dPKqHv3vX0BBsUFZt.lock"));
-    if (!lockfile.tryLock(100)) {
-        // Already running
-        return -1;
-    }
-
     QCommandLineParser parser;
     parser.setApplicationDescription("Twitch.tv client");
     parser.addHelpOption();
@@ -148,13 +143,28 @@ int main(int argc, char *argv[])
     rootContext->setContextProperty("g_games", ChannelManager::getInstance()->getGamesModel());
     rootContext->setContextProperty("vodsModel", VodManager::getInstance()->getModel());
 
+
+    rootContext->setContextProperty("g_instance", "main");
+
+#ifndef Q_OS_ANDROID
+    //Single application solution
+    QLockFile lockfile(QDir::temp().absoluteFilePath("wz0dPKqHv3vX0BBsUFZt.lock"));
+    if (!lockfile.tryLock(100)) {
+        // Already running
+        if (!SettingsManager::getInstance()->multipleInstances()) {
+            return -1;
+        }
+        rootContext->setContextProperty("g_instance", "child");
+    }
+#endif
+
     // Register qml components
     registerQmlComponents(&app);
 
     // Load QML content
     engine.load(QUrl("qrc:/main.qml"));
 
-    // Load app settings
+    // Trigger setting property notifications
     SettingsManager::getInstance()->load();
 
 #ifndef Q_OS_ANDROID

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,31 @@ int main(int argc, char *argv[])
 
     // Load app settings
     SettingsManager::getInstance()->load();
+
+    auto opengl = SettingsManager::getInstance()->opengl().toLower();
+
+    // OpenGL implementation used to render app.
+    // Need to be set before constructing QGuiApplication
+    // http://doc.qt.io/qt-5/qt.html#ApplicationAttribute-enum
+    if (opengl.contains("desktop")) {
+        QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+    } else if(opengl.contains("software")) {
+        QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);
+    } else {
+        QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
+#ifdef QT_OPENGL_DYNAMIC
+        qputenv("QT_OPENGL", "angle");
+#endif
+#ifdef Q_OS_WIN
+        if (opengl.contains("d3d11"))
+            qputenv("QT_ANGLE_PLATFORM", "d3d11");
+        else if (opengl.contains("d3d9"))
+            qputenv("QT_ANGLE_PLATFORM", "d3d9");
+        else if (opengl.contains("warp"))
+            qputenv("QT_ANGLE_PLATFORM", "warp");
+#endif
+    }
+
 #ifndef Q_OS_ANDROID
     QApplication app(argc, argv);
 #else

--- a/src/model/channellistmodel.cpp
+++ b/src/model/channellistmodel.cpp
@@ -214,14 +214,16 @@ Channel *ChannelListModel::find(const quint32 &id)
 void ChannelListModel::clearView()
 {
     //Gives a sign to drop all channels from view, without removing them
-    beginRemoveRows(QModelIndex(), 0, channels.size());
-    endRemoveRows();
+    if (!channels.isEmpty()) {
+        beginRemoveRows(QModelIndex(), 0, channels.size() - 1);
+        endRemoveRows();
+    }
 }
 
 void ChannelListModel::clear()
 {
     if (!channels.isEmpty()){
-        beginRemoveRows(QModelIndex(), 0, channels.size());
+        beginRemoveRows(QModelIndex(), 0, channels.size() - 1);
         qDeleteAll(channels);
         channels.clear();
         channelIdIndex.clear();

--- a/src/model/gamelistmodel.cpp
+++ b/src/model/gamelistmodel.cpp
@@ -118,7 +118,7 @@ Game *GameListModel::find(const uint id)
 void GameListModel::clear()
 {
     if (!games.isEmpty()){
-        beginRemoveRows(QModelIndex(), 0, games.size());
+        beginRemoveRows(QModelIndex(), 0, games.size() - 1);
         qDeleteAll(games);
         games.clear();
         endRemoveRows();

--- a/src/model/settingsmanager.cpp
+++ b/src/model/settingsmanager.cpp
@@ -25,6 +25,7 @@ SettingsManager::SettingsManager(QObject *parent) :
     mOpengl = "opengl es";
 #endif
     mQuality = "source";
+    mDecoder = "auto";
     mChatEdge = 1;
     mLightTheme = false;
     mFont = "";
@@ -70,6 +71,10 @@ void SettingsManager::load()
 
     if (settings->contains("quality")) {
         setQuality(settings->value("quality").toString());
+    }
+
+    if (settings->contains("decoder")) {
+        setDecoder(settings->value("decoder").toString());
     }
 
     if (settings->contains("volumeLevel")) {
@@ -291,6 +296,22 @@ void SettingsManager::setQuality(const QString &quality)
         qDebug() << "quality changed to" << quality;
     }
     emit qualityChanged();
+}
+
+QString SettingsManager::decoder() const
+{
+    return mDecoder;
+}
+
+void SettingsManager::setDecoder(const QString &decoder)
+{
+    if (mDecoder != decoder) {
+        mDecoder = decoder;
+        settings->setValue("decoder", decoder);
+
+        qDebug() << "decoder changed to" << decoder;
+    }
+    emit decoderChanged();
 }
 
 QString SettingsManager::accessToken() const

--- a/src/model/settingsmanager.cpp
+++ b/src/model/settingsmanager.cpp
@@ -12,6 +12,7 @@ SettingsManager::SettingsManager(QObject *parent) :
     //Initial values
     mAlert = true;
     mCloseToTray = false;
+    mMultipleInstances = false;
     mAlertPosition = 1;
     mMinimizeOnStartup = false;
     mTextScaleFactor = 1.0;
@@ -48,6 +49,10 @@ void SettingsManager::load()
 
     if (settings->contains("closeToTray")) {
         setCloseToTray(settings->value("closeToTray").toBool());
+    }
+
+    if (settings->contains("multipleInstances")) {
+        setMultipleInstances(settings->value("multipleInstances").toBool());
     }
 
     if (settings->contains("minimizeOnStartup")) {
@@ -121,6 +126,22 @@ void SettingsManager::setCloseToTray(bool closeToTray)
         qDebug() << "closeToTray changed to" << closeToTray;
     }
     emit closeToTrayChanged();
+}
+
+bool SettingsManager::multipleInstances() const
+{
+    return mMultipleInstances;
+}
+
+void SettingsManager::setMultipleInstances(bool multipleInstances)
+{
+    if (mMultipleInstances != multipleInstances) {
+        mMultipleInstances = multipleInstances;
+        settings->setValue("multipleInstances", multipleInstances);
+
+        qDebug() << "multipleInstances changed to" << multipleInstances;
+    }
+    emit multipleInstancesChanged();
 }
 
 int SettingsManager::alertPosition() const

--- a/src/model/settingsmanager.cpp
+++ b/src/model/settingsmanager.cpp
@@ -19,6 +19,11 @@ SettingsManager::SettingsManager(QObject *parent) :
     mVolumeLevel = 100;
     mOfflineNotifications = false;
     mAccessToken = "";
+#ifdef Q_OS_WIN
+    mOpengl = "angle (d3d9)";
+#else
+    mOpengl = "opengl es";
+#endif
     mQuality = "source";
     mChatEdge = 1;
     mLightTheme = false;
@@ -57,6 +62,10 @@ void SettingsManager::load()
 
     if (settings->contains("minimizeOnStartup")) {
         setMinimizeOnStartup(settings->value("minimizeOnStartup").toBool());
+    }
+
+    if (settings->contains("opengl")) {
+        setOpengl(settings->value("opengl").toString());
     }
 
     if (settings->contains("quality")) {
@@ -250,6 +259,22 @@ void SettingsManager::setTextScaleFactor(double textScaleFactor)
         qDebug() << "textScaleFactor changed to" << textScaleFactor;
     }
     emit textScaleFactorChanged();
+}
+
+QString SettingsManager::opengl() const
+{
+    return mOpengl;
+}
+
+void SettingsManager::setOpengl(const QString &opengl)
+{
+    if (mOpengl != opengl) {
+        mOpengl = opengl;
+        settings->setValue("opengl", opengl);
+
+        qDebug() << "opengl changed to" << opengl;
+    }
+    emit openglChanged();
 }
 
 QString SettingsManager::quality() const

--- a/src/model/settingsmanager.h
+++ b/src/model/settingsmanager.h
@@ -12,6 +12,7 @@ class SettingsManager : public QObject
 
     Q_PROPERTY(bool alert READ alert WRITE setAlert NOTIFY alertChanged)
     Q_PROPERTY(bool closeToTray READ closeToTray WRITE setCloseToTray NOTIFY closeToTrayChanged)
+    Q_PROPERTY(bool multipleInstances READ multipleInstances WRITE setMultipleInstances NOTIFY multipleInstancesChanged)
     Q_PROPERTY(int alertPosition READ alertPosition WRITE setAlertPosition NOTIFY alertPositionChanged)
     Q_PROPERTY(int volumeLevel READ volumeLevel WRITE setVolumeLevel NOTIFY volumeLevelChanged)
     Q_PROPERTY(bool minimizeOnStartup READ minimizeOnStartup WRITE setMinimizeOnStartup NOTIFY minimizeOnStartupChanged)
@@ -28,6 +29,7 @@ class SettingsManager : public QObject
 
     bool mAlert;
     bool mCloseToTray;
+    bool mMultipleInstances;
     int mAlertPosition;
     int mVolumeLevel;
     bool mMinimizeOnStartup;
@@ -53,6 +55,9 @@ public:
 
     bool closeToTray() const;
     void setCloseToTray(bool closeToTray);
+
+    bool multipleInstances() const;
+    void setMultipleInstances(bool multipleInstances);
 
     int alertPosition() const;
     void setAlertPosition(int alertPosition);
@@ -93,6 +98,7 @@ public:
 signals:
     void alertChanged();
     void closeToTrayChanged();
+    void multipleInstancesChanged();
     void alertPositionChanged();
     void volumeLevelChanged();
     void minimizeOnStartupChanged();

--- a/src/model/settingsmanager.h
+++ b/src/model/settingsmanager.h
@@ -21,6 +21,7 @@ class SettingsManager : public QObject
     Q_PROPERTY(double textScaleFactor READ textScaleFactor WRITE setTextScaleFactor NOTIFY textScaleFactorChanged)
     Q_PROPERTY(QString opengl READ opengl WRITE setOpengl NOTIFY openglChanged)
     Q_PROPERTY(QString quality READ quality WRITE setQuality NOTIFY qualityChanged)
+    Q_PROPERTY(QString decoder READ decoder WRITE setDecoder NOTIFY decoderChanged)
     Q_PROPERTY(QString accessToken READ accessToken WRITE setAccessToken NOTIFY accessTokenChanged)
     Q_PROPERTY(bool hasAccessToken READ hasAccessToken NOTIFY accessTokenChanged)
     Q_PROPERTY(bool lightTheme READ lightTheme WRITE setLightTheme NOTIFY lightThemeChanged)
@@ -39,6 +40,7 @@ class SettingsManager : public QObject
     double mTextScaleFactor;
     QString mOpengl;
     QString mQuality;
+    QString mDecoder;
     QString mAccessToken;
     int mChatEdge;
     bool mLightTheme;
@@ -85,6 +87,9 @@ public:
     QString quality() const;
     void setQuality(const QString &quality);
 
+    QString decoder() const;
+    void setDecoder(const QString &decoder);
+
     QString accessToken() const;
 
     void setHiDpi(bool dpi);
@@ -112,6 +117,7 @@ signals:
     void textScaleFactorChanged();
     void openglChanged();
     void qualityChanged();
+    void decoderChanged();
     void lightThemeChanged();
     void accessTokenChanged(QString accessToken);
     void fontChanged();

--- a/src/model/settingsmanager.h
+++ b/src/model/settingsmanager.h
@@ -19,6 +19,7 @@ class SettingsManager : public QObject
     Q_PROPERTY(int chatEdge READ chatEdge WRITE setChatEdge NOTIFY chatEdgeChanged)
     Q_PROPERTY(bool offlineNotifications READ offlineNotifications WRITE setOfflineNotifications NOTIFY offlineNotificationsChanged)
     Q_PROPERTY(double textScaleFactor READ textScaleFactor WRITE setTextScaleFactor NOTIFY textScaleFactorChanged)
+    Q_PROPERTY(QString opengl READ opengl WRITE setOpengl NOTIFY openglChanged)
     Q_PROPERTY(QString quality READ quality WRITE setQuality NOTIFY qualityChanged)
     Q_PROPERTY(QString accessToken READ accessToken WRITE setAccessToken NOTIFY accessTokenChanged)
     Q_PROPERTY(bool hasAccessToken READ hasAccessToken NOTIFY accessTokenChanged)
@@ -36,6 +37,7 @@ class SettingsManager : public QObject
     bool mSwapChat;
     bool mOfflineNotifications;
     double mTextScaleFactor;
+    QString mOpengl;
     QString mQuality;
     QString mAccessToken;
     int mChatEdge;
@@ -77,6 +79,9 @@ public:
     double textScaleFactor() const;
     void setTextScaleFactor(double textScaleFactor);
 
+    QString opengl() const;
+    void setOpengl(const QString &opengl);
+
     QString quality() const;
     void setQuality(const QString &quality);
 
@@ -105,6 +110,7 @@ signals:
     void chatEdgeChanged();
     void offlineNotificationsChanged();
     void textScaleFactorChanged();
+    void openglChanged();
     void qualityChanged();
     void lightThemeChanged();
     void accessTokenChanged(QString accessToken);

--- a/src/model/vodlistmodel.cpp
+++ b/src/model/vodlistmodel.cpp
@@ -114,7 +114,7 @@ Vod *VodListModel::find(const QString id)
 void VodListModel::clear()
 {
     if (!vods.isEmpty()){
-        beginRemoveRows(QModelIndex(), 0, vods.size());
+        beginRemoveRows(QModelIndex(), 0, vods.size() - 1);
         qDeleteAll(vods);
         vods.clear();
         endRemoveRows();

--- a/src/player/mpvobject.cpp
+++ b/src/player/mpvobject.cpp
@@ -26,6 +26,7 @@ MpvObject::MpvObject(QQuickItem * parent)
 #endif
 
     // Make use of the MPV_SUB_API_OPENGL_CB API.
+    mpv::qt::set_option_variant(mpv, "gpu-context", "angle");
     mpv::qt::set_option_variant(mpv, "vo", "opengl-cb");
     //mpv::qt::set_option_variant(mpv, "input-cursor", "no");
 

--- a/src/qml/MpvBackend.qml
+++ b/src/qml/MpvBackend.qml
@@ -25,6 +25,8 @@ togglePause()       -- Toggles between playing and pausing
 stop()              -- Stops playback
 seekTo(ms)          -- Seeks to milliseconds in the current source, works only on vods
 setVolume(vol)      -- Number between 0 - 100
+getDecoder()        -- Return list of video decoders
+setDecoder(idx)     -- Set video decoder
 
 Signals needed:
 playingResumed()    -- Signaled when playback toggles from paused / stopped to playing
@@ -94,7 +96,29 @@ Item {
     }
 
     function setVolume(vol) {
+        if (Qt.platform.os === "linux")
+            volume = Math.round(Math.log(vol) / Math.log(100))
+        else
         volume = Math.round(vol)
+    }
+
+    function getDecoder() {
+        var defaultDecoders = []
+        if (Qt.platform.os == "windows") {
+            defaultDecoders = [ "dxva2-copy", "d3d11va-copy", "cuda-copy", "no" ]
+        } else if (Qt.platform.os == "osx" || Qt.platform.os == "ios") {
+            defaultDecoders = [ "videotoolbox", "no" ]
+        } else if(Qt.platform.os == "android") {
+            defaultDecoders = [ "mediacodec_embed", "no" ]
+        } else if (Qt.platform.os == "linux") {
+            defaultDecoders = [ "vaapi-copy", "vdpau-copy", "no" ]
+        }
+        return [ "auto" ].concat(defaultDecoders)
+    }
+
+    function setDecoder(idx) {
+        var decoderName = getDecoder()[idx]
+        renderer.setProperty("hwdec", decoderName)
     }
 
     signal playingResumed()

--- a/src/qml/MpvBackend.qml
+++ b/src/qml/MpvBackend.qml
@@ -99,7 +99,7 @@ Item {
         if (Qt.platform.os === "linux")
             volume = Math.round(Math.log(vol) / Math.log(100))
         else
-        volume = Math.round(vol)
+            volume = Math.round(vol)
     }
 
     function getDecoder() {
@@ -157,6 +157,16 @@ Item {
         renderer.setProperty("volume", volume)
     }
 
+    Timer {
+        id: positionTimer
+        interval: 1000
+        running: false
+        repeat: true
+        onTriggered: {
+            if (root.status === "PLAYING")
+                root.position += 1
+        }
+    }
 
     MpvObject {
         id: renderer
@@ -169,14 +179,17 @@ Item {
 
         onPlayingStopped: {
             root.status = "STOPPED"
+            positionTimer.stop()
         }
 
         onPlayingPaused: {
             root.status = "PAUSED"
+            positionTimer.stop()
         }
 
         onPlayingResumed: {
             root.status = "PLAYING"
+            positionTimer.start()
         }
 
         onPositionChanged: {
@@ -194,6 +207,8 @@ Item {
 
             if (root.position !== adjustedPosition)
                 root.position = adjustedPosition
+
+            positionTimer.restart()
         }
 
         Component.onCompleted: {

--- a/src/qml/MultimediaBackend.qml
+++ b/src/qml/MultimediaBackend.qml
@@ -25,6 +25,8 @@ togglePause()       -- Toggles between playing and pausing
 stop()              -- Stops playback
 seekTo(pos)         -- Seeks to milliseconds in the current source, works only on vods
 setVolume(vol)      -- Number between 0 - 100
+getDecoder()        -- Return list of video decoders
+setDecoder(idx)     -- Set video decoder
 
 Signals needed:
 playingResumed()    -- Signaled when playback toggles from paused / stopped to playing
@@ -84,6 +86,15 @@ Item {
 
     function setVolume(vol) {
         volume = Math.round(vol)
+    }
+
+    function getDecoder() {
+        var defaultDecoders = []
+        return defaultDecoders
+    }
+
+    function setDecoder(idx) {
+
     }
 
     signal playingResumed()

--- a/src/qml/OptionsView.qml
+++ b/src/qml/OptionsView.qml
@@ -185,6 +185,56 @@ Page {
                         checked: Settings.multipleInstances
                         onClicked: Settings.multipleInstances = checked
                     }
+
+                    RowLayout {
+                        width: parent.width
+
+                        OptionCombo {
+                            id: openglOption
+                            text: "OpenGL (needs restart)"
+                            model: {
+                                var opengl = [ ]
+                                if (Qt.platform.os === "windows") {
+                                    opengl = ["angle", "angle (d3d11)", "angle (d3d9)", "angle (warp)"]
+                                } else {
+                                    opengl = ["opengl es"]
+                                }
+                                opengl = opengl.concat(["desktop", "software"])
+                                return opengl
+                            }
+                            Layout.fillWidth: true
+                            property var defaultValue
+
+                            onActivated: {
+                                Settings.opengl = model[currentIndex]
+                            }
+
+                            Component.onCompleted: {
+                                defaultValue = Settings.opengl
+                                selectItem(defaultValue)
+                            }
+
+                            function selectItem(name) {
+                                for (var i in model) {
+                                    if (model[i] === name) {
+                                        currentIndex = i;
+                                        return;
+                                    }
+                                }
+                                //None found, attempt to select first item
+                                currentIndex = 0
+                            }
+                        }
+
+                        Button {
+                            text: "Reset"
+                            font.pointSize: 9
+                            onClicked: {
+                                openglOption.selectItem(openglOption.defaultValue)
+                            }
+                        }
+                    }
+
                 }
             }
 

--- a/src/qml/OptionsView.qml
+++ b/src/qml/OptionsView.qml
@@ -177,6 +177,14 @@ Page {
                         checked: Settings.keepOnTop
                         onClicked: Settings.keepOnTop = checked
                     }
+
+                    Switch {
+                        visible: !isMobile()
+                        id: mulipleInstancesOption
+                        text: "Allow multiple instances"
+                        checked: Settings.multipleInstances
+                        onClicked: Settings.multipleInstances = checked
+                    }
                 }
             }
 

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -585,12 +585,44 @@ Page {
                     }
 
                     onValueChanged: {
-                        var val = value
-                        if (Qt.platform === "linux" && player_backend === "mpv")
-                            val = Math.round(Math.log(val) / Math.log(100))
+                        renderer.setVolume(value)
+                        Settings.volumeLevel = value;
+                    }
+                }
+                ComboBox {
+                    id: hwaccelBox
+                    font.pointSize: 9
+                    font.bold: true
+                    focusPolicy: Qt.NoFocus
+                    flat: true
+                    Layout.fillWidth: true
+                    Layout.maximumWidth: 140
+                    Layout.minimumWidth: 100
+                    visible: renderer.getDecoder().length > 1
 
-                        renderer.setVolume(val)
-                        Settings.volumeLevel = val;
+                    onCurrentIndexChanged: {
+                        renderer.setDecoder(currentIndex)
+                        loadAndPlay()
+                        Settings.decoder = hwaccelBox.model[currentIndex]
+                        pArea.refreshHeaders()
+                    }
+
+                    Component.onCompleted: {
+                        var decoder = renderer.getDecoder()
+                        hwaccelBox.model = decoder
+                        selectItem(Settings.decoder)
+                        renderer.setDecoder(currentIndex)
+                    }
+
+                    function selectItem(name) {
+                        for (var i in hwaccelBox.model) {
+                            if (hwaccelBox.model[i] === name) {
+                                currentIndex = i;
+                                return;
+                            }
+                        }
+                        //None found, attempt to select first item
+                        currentIndex = 0
                     }
                 }
 

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -270,8 +270,8 @@ Page {
                 }
             }
             if (!seekBar.pressed) {
-            seekBar.value = newPos
-        }
+                seekBar.value = newPos
+            }
         }
 
         onPlayingResumed: {
@@ -288,6 +288,88 @@ Page {
 
         onStatusChanged: {
             PowerManager.screensaver = (renderer.status !== "PLAYING")
+        }
+    }
+
+    Shortcut {
+        sequence: "Space"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            renderer.togglePause()
+            clickRect.run()
+            pArea.refreshHeaders()
+        }
+    }
+
+    Shortcut {
+        sequence: "0"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            reloadStream()
+            pArea.refreshHeaders()
+        }
+    }
+
+    Shortcut {
+        sequence: "f"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            appFullScreen = !appFullScreen
+        }
+    }
+
+    Shortcut {
+        sequence: "Esc"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            appFullScreen = false
+        }
+    }
+
+    Shortcut {
+        sequence: "m"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            volumeBtn.toggleMute()
+            pArea.refreshHeaders()
+        }
+    }
+
+    Shortcut {
+        sequence: "Up"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            volumeSlider.value += 5
+            pArea.refreshHeaders()
+        }
+    }
+
+    Shortcut {
+        sequence: "Down"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            volumeSlider.value -= 5
+            pArea.refreshHeaders()
+        }
+    }
+
+    Shortcut {
+        sequence: "Right"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            if (!isVod || seekBar.pressed) return
+            seekBar.seek(seekBar.value + 5)
+            pArea.refreshHeaders()
+        }
+    }
+
+    Shortcut {
+        sequence: "Left"
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            if (!isVod || seekBar.pressed) return
+            seekBar.seek(seekBar.value - 5)
+            pArea.refreshHeaders()
         }
     }
 
@@ -395,8 +477,8 @@ Page {
 
         onClicked: {
             clickRect.run()
-                clickTimer.restart()
-                refreshHeaders()
+            clickTimer.restart()
+            refreshHeaders()
         }
         onDoubleClicked: {
             if (!isMobile()) {
@@ -620,7 +702,7 @@ Page {
                     fill: parent
                     rightMargin: 5
                     leftMargin: 5
-                }
+                }                
                 spacing: 0
 
                 IconButtonFlat {
@@ -776,6 +858,7 @@ Page {
                     id: sourcesBox
                     font.pointSize: 9
                     font.bold: true
+                    focusPolicy: Qt.NoFocus
                     flat: true
                     Layout.fillWidth: true
                     Layout.maximumWidth: 140
@@ -804,14 +887,14 @@ Page {
                     visible: !appFullScreen && !isMobile() && !chat.visible && parent.width > 440
                     text: "\ue3bc"
                     onClicked: fitToAspectRatio()
-        }
+                }
 
                 IconButtonFlat {
                     id: fsBtn
                     visible: !isMobile()
                     text: !appFullScreen ? "\ue5d0" : "\ue5d1"
                     onClicked: appFullScreen = !appFullScreen
-            }
+                }
             }
         }
     }

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -210,7 +210,7 @@ Page {
     }
 
     function setWatchingTitle(){
-        var description = currentChannel.title
+        var description = currentChannel.title + (isVod ? ("\r\n" + currentChannel.name) : "")
                 + (currentChannel.game ? " playing " + currentChannel.game : "")
                 + (isVod ? " (VOD)" : "");
         setHeaderText(description);

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -536,12 +536,6 @@ Page {
                     onClicked: reloadStream()
                 }
 
-                //spacer
-                Item {
-                    Layout.minimumWidth: 0
-                    Layout.fillWidth: true
-                }
-
                 IconButtonFlat {
                     id: cropBtn
                     visible: !appFullScreen && !isMobile() && !chat.visible && parent.width > 440
@@ -589,6 +583,38 @@ Page {
                         Settings.volumeLevel = value;
                     }
                 }
+
+                //spacer
+                Label {
+                    id: videoPositionLabel
+                    Layout.minimumWidth: 0
+                    Layout.fillWidth: true
+                    font.bold: true
+                    font.pointSize: 8
+                    Material.foreground: Material.Grey
+                    horizontalAlignment: Qt.AlignLeft
+                    clip: true
+                    function updateText() {
+                        if (!isVod) return ""
+                        var formatTime = function(seconds) {
+                            var d = new Date()
+                            d.setTime(seconds * 1000)
+                            d.setMinutes(d.getMinutes() + d.getTimezoneOffset())
+                            return d.toTimeString()
+                        }
+                        text = formatTime(seekBar.value) + "/" + formatTime(duration)
+                    }
+                    Connections {
+                        target: seekBar
+                        onValueChanged: videoPositionLabel.updateText()
+                    }
+                    Connections {
+                        target: renderer
+                        onPlayingStopped: videoPositionLabel.text = ""
+                    }
+                }
+
+
                 ComboBox {
                     id: hwaccelBox
                     font.pointSize: 9

--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -121,7 +121,7 @@ Page {
     function loadAndPlay(){
         var description = setWatchingTitle();
 
-        var start = !isVod ? -1 : seekBar.position
+        var start = !isVod ? -1 : seekBar.value
 
         var url = streamMap[Settings.quality]
 

--- a/src/qml/QtAVBackend.qml
+++ b/src/qml/QtAVBackend.qml
@@ -25,6 +25,8 @@ togglePause()       -- Toggles between playing and pausing
 stop()              -- Stops playback
 seekTo(pos)         -- Seeks to milliseconds in the current source, works only on vods
 setVolume(vol)      -- Number between 0 - 100
+getDecoder()        -- Return list of video decoders
+setDecoder(idx)     -- Set video decoder
 
 Signals needed:
 playingResumed()    -- Signaled when playback toggles from paused / stopped to playing
@@ -83,6 +85,40 @@ Item {
 
     function setVolume(vol) {
         volume = Math.round(vol)
+    }
+
+    function getDecoder() {
+        var defaultDecoders = renderer.videoCodecs
+        var decoder = [ "auto" ]
+        decoder = decoder.concat(defaultDecoders);
+        return decoder
+    }
+
+    function setDecoder(idx) {
+        var decoderName = getDecoder()[idx]
+
+        var opt = renderer.videoCodecOptions
+        opt["copyMode"] = Qt.platform.os == "android" ? "OptimizedCopy" : "ZeroCopy"
+        renderer.videoCodecOptions = opt
+
+        if (decoderName === "auto") {
+            if (g_instance === "child") {
+                // disable automatic hw acceleration for multiple instances (usually results in lag)
+                renderer.videoCodecPriority = [ "FFmpeg" ]
+            } else if (Qt.platform.os == "windows") {
+                renderer.videoCodecPriority = [ "DXVA", "FFmpeg" ]
+            } else if (Qt.platform.os == "winrt" || Qt.platform.os == "winphone") {
+                renderer.videoCodecPriority = [ "D3D11", "FFmpeg" ]
+            } else if (Qt.platform.os == "osx" || Qt.platform.os == "ios") {
+                renderer.videoCodecPriority = [ "VideoToolbox", "FFmpeg" ]
+            } else if(Qt.platform.os == "android") {
+                renderer.videoCodecPriority = [ "MediaCodec", "FFmpeg" ]
+            } else if (Qt.platform.os == "linux") {
+                renderer.videoCodecPriority = [ "VAAPI", "FFmpeg" ]
+            }
+        } else {
+            renderer.videoCodecPriority = [ decoderName ]
+        }
     }
 
     signal playingResumed()

--- a/src/qml/components/IconButtonFlat.qml
+++ b/src/qml/components/IconButtonFlat.qml
@@ -5,4 +5,5 @@ RoundButton {
     font.pointSize: 16
     flat: true
     font.family: "Material Icons"
+    focusPolicy: Qt.NoFocus
 }

--- a/src/qml/components/OptionCombo.qml
+++ b/src/qml/components/OptionCombo.qml
@@ -22,6 +22,7 @@ RowLayout {
     property alias text: label.text
     property alias selection: combo.currentIndex
     property alias model: combo.model
+    property alias currentIndex: combo.currentIndex
 
     signal activated(int index)
 

--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -157,6 +157,7 @@ Page {
             id: pinBtn
             checkable: true
             font.family: "Material Icons"
+            focusPolicy: Qt.NoFocus
             text: checked ? "\ue897" : "\ue898"
         }
 


### PR DESCRIPTION
Adds the option to change the decoder of the video to the QtAV and mpv backend.
On my test machine with windows 10 and a Intel i5 3570k and a AMD graphics card the performance differences are quite drastic for a normal 1080p stream:

    Cpu Usage:
    qtmultimedia: 25%
    mpv (dxva_copy): 10%
    mpv (no): 25%
    QtAV (DXVA zero-copy): 3%
    QtAV (FFmpeg): 8% 

Artifacts: https://ci.appveyor.com/project/mrgreywater/orion

This commit also gives an option to start multiple instances, fixes some gui issues and reorders the player controls to a more similar order as youtube etc. I can potentially split those up into more commits or PRs as necessary.

edit: there are still some issues, will push a fix for some things soon