### PR TITLE
appveyor more builds, fix redist

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,32 +1,52 @@
 environment:
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+
   matrix:
   - platform: x64
+    player: qtav
     configuration: release
-    qt: 5.10
+    qt: 5.10 #version freeze until fix of https://bugreports.qt.io/browse/QTBUG-61822
     cc: VS2017
     QTDIR: C:\Qt\5.10\msvc2017_64
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    OPENSSL_DIR: C:\OpenSSL-Win64
-
+    
   - platform: x86
+    player: qtav
     configuration: release
     qt: 5.10
     cc: VS2015
     toolchain_version: 14
     QTDIR: C:\Qt\5.10\msvc2015
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    OPENSSL_DIR: C:\OpenSSL-Win32
 
+  - platform: x64
+    player: multimedia
+    configuration: release
+    qt: 5.10
+    cc: VS2017
+    QTDIR: C:\Qt\5.10\msvc2017_64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+  - platform: x64
+    player: mpv
+    configuration: release
+    qt: 5.10
+    cc: VS2017
+    QTDIR: C:\Qt\5.10\msvc2017_64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    
 matrix:
   fast_finish: false
 
 cache:
-  - C:\projects\AV -> appveyor.yml
+  - C:\projects\OpenSSL -> ci\build_openssl.bat
+  - C:\projects\QtAV -> ci\build_qtav.bat
+  - C:\projects\mpv -> ci\build_mpv.bat
 
 init:
-  - set vcarch=%platform%
-  - set arch=%platform%
   - set CL=/MP
+  - set vcarch=%platform%
   - if "%platform%" == "x64" set vcarch=amd64
   - set VCREDIST=vcredist_%platform%.exe
   - if %cc%==VS2017 set VCREDIST=vc_redist.%platform%.exe
@@ -43,51 +63,45 @@ init:
   - echo PATH=%PATH%
 
 install:
-  - git clone https://github.com/wang-bin/QtAV.git "C:\projects\QtAV"
-  - cd "C:\projects\QtAV" && git submodule update --init
-  - cd "C:\projects" && C:\projects\QtAV\tools\ci\win\install_dep.bat
-  - cd "C:\projects\QtAV"
-  - qmake QtAV.pro "CONFIG+=%configuration%" "CONFIG+=no-examples" "CONFIG+=no-tests"
-  - nmake %configuration%
-  - sdk_install.bat
-
+  - call "%APPVEYOR_BUILD_FOLDER%\ci\build_openssl.bat"
+  - if %player%==qtav call "%APPVEYOR_BUILD_FOLDER%\ci\build_qtav.bat"
+  - if %player%==mpv call "%APPVEYOR_BUILD_FOLDER%\ci\build_mpv.bat"
+  
 before_build:
   - echo APPVEYOR_BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER%
   - cd %APPVEYOR_BUILD_FOLDER%
   - git submodule update --init
 
 build_script:
-  - qmake orion.pro "CONFIG+=%configuration%" "CONFIG+=qtav"
+  - qmake orion.pro "CONFIG+=%configuration%" "CONFIG+=%player%"
   - mkdir libs
-  - copy /y "%OPENSSL_DIR%\ssleay32.dll" libs
-  - copy /y "%OPENSSL_DIR%\libeay32.dll" libs
+  - copy /y "%OPENSSL_DIR%\*eay32.dll" libs
+  - if %player%==mpv copy /y %QTDIR%\bin\mpv-1.dll libs
   - nmake %configuration%
   - windeployqt --qmldir src\qml %configuration%\orion.exe
-  - copy /y %QTDIR%\bin\av*-*.dll %configuration%
-  - copy /y %QTDIR%\bin\sw*-*.dll %configuration%
-  - copy /y %QTDIR%\bin\QtAV*.dll %configuration%
+  - if %player%==qtav copy /y %QTDIR%\bin\av*-*.dll %configuration% && copy /y %QTDIR%\bin\sw*-*.dll %configuration% && copy /y %QTDIR%\bin\QtAV*.dll %configuration%
   - dir /s
 
 after_build:
-  - 7z a orion_%configuration%_%platform%_snapshot_%APPVEYOR_REPO_COMMIT%.zip . -x!.git
+  - 7z a orion_%configuration%_%player%_%platform%_snapshot_%APPVEYOR_REPO_COMMIT%.zip . -x!.git
   - del %configuration%\*.obj
   - del %configuration%\*.cpp
   - del %configuration%\*.h
   - del %configuration%\*.res
   - if %configuration%==release copy "resources\orion-installer.iss" orion-installer.iss
-  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /DPlatform=%platform% /DAdditionalRedist="%APPVEYOR_BUILD_FOLDER%\%configuration%\%VCREDIST%" /F"orion-%configuration%-%platform%" "orion-installer.iss"
+  - if %configuration%==release "C:\Program Files (x86)\Inno Setup 5\iscc.exe" /DPlatform=%platform% /DAdditionalRedist="%APPVEYOR_BUILD_FOLDER%\%configuration%\%VCREDIST%" /F"orion-%configuration%-%player%-%platform%" "orion-installer.iss"
 
 artifacts:
-  - path: orion_$(configuration)_$(platform)_snapshot_$(APPVEYOR_REPO_COMMIT).zip
-    name: orion windows $(configuration) $(platform) snapshot zip
-  - path: orion-$(configuration)-$(platform).exe
+  - path: orion_$(configuration)_$(player)_$(platform)_snapshot_$(APPVEYOR_REPO_COMMIT).zip
+    name: orion windows $(configuration) $(player) $(platform) snapshot zip
+  - path: orion-$(configuration)-$(player)-$(platform).exe
     name: Windows installer
 
 deploy:
 - provider: GitHub
   auth_token:
     secure: kna2fyW9Q70WCBxJn/YYJ4pupSRog8FFp6BhKOjr6rtfMIGGtN52UuiMtc90RTla
-  artifact: orion-$(configuration)-$(platform).exe
+  artifact: orion-$(configuration)-$(player)-$(platform).exe
   prerelease: true
   force_update: true
   on:

--- a/ci/build_mpv.bat
+++ b/ci/build_mpv.bat
@@ -1,0 +1,27 @@
+set MPVDIR=C:\projects\mpv\%cc%\%platform%
+setlocal enableextensions
+
+if %platform%==x86 set mpv_platform=i686
+if %platform%==x64 set mpv_platform=x86_64
+
+if not exist %MPVDIR% mkdir %MPVDIR%
+cd %MPVDIR%
+
+if exist %MPVDIR%\mpv-1.dll goto :def
+appveyor DownloadFile "https://kent.dl.sourceforge.net/project/mpv-player-windows/libmpv/mpv-dev-%mpv_platform%-20181007-git-2b0b9bb.7z" -FileName mpv-dev.7z
+7z x -y mpv-dev.7z
+
+:def
+if exist %MPVDIR%\mpv.def goto :lib
+appveyor DownloadFile "https://raw.githubusercontent.com/mpv-player/mpv/master/libmpv/mpv.def" -FileName mpv_dl.def
+echo EXPORTS > mpv.def
+type mpv_dl.def >> mpv.def
+
+:lib
+if exist %MPVDIR%\mpv.lib goto :install
+lib /def:mpv.def /name:mpv-1.dll /out:mpv.lib /MACHINE:%platform%
+
+:install
+copy /y %MPVDIR%\mpv.lib %QTDIR%\lib\mpv.lib
+copy /y %MPVDIR%\mpv-1.dll %QTDIR%\bin\mpv-1.dll
+xcopy %MPVDIR%\include %QTDIR%\include\mpv /y /s /e /h /i

--- a/ci/build_openssl.bat
+++ b/ci/build_openssl.bat
@@ -1,0 +1,25 @@
+set OPENSSL_DIR=C:\projects\OpenSSL\%cc%\%platform%
+set "PATH=C:\Program Files (x86)\nasm;%PATH%"
+setlocal enableextensions
+
+if exist %OPENSSL_DIR% goto :eof
+
+if not exist "C:\projects\OpenSSL" mkdir "C:\projects\OpenSSL"
+cd "C:\projects\OpenSSL"
+if not exist ssl.zip ( appveyor DownloadFile "https://codeload.github.com/openssl/openssl/zip/OpenSSL_1_0_2p" -FileName ssl.zip || goto :eof )
+if not exist build ( 7z x ssl.zip > NUL && move openssl* build || goto :eof )
+
+cd build
+
+if %platform%==x64 ( 
+    cmd /c "perl Configure VC-WIN64A && ms\do_win64a"
+) else ( 
+    curl -L -o nasminst.exe http://libgd.blob.core.windows.net/nasm/nasm-2.07-installer.exe
+    start /wait nasminst.exe /S
+    cmd /c "perl Configure VC-WIN32 && ms\do_nasm"
+)
+
+nmake -f ms\ntdll.mak || goto :eof
+
+mkdir %OPENSSL_DIR%\..\
+move /Y out32dll %OPENSSL_DIR%

--- a/ci/build_qtav.bat
+++ b/ci/build_qtav.bat
@@ -1,0 +1,22 @@
+set QTAV_DIR=C:\projects\QtAV\%cc%\%platform%\%configuration%
+setlocal enableextensions
+
+set arch=%platform%
+
+if exist %QTAV_DIR%\sdk_install.bat goto :installdeps
+mkdir %QTAV_DIR%\..\
+
+git clone --recursive https://github.com/wang-bin/QtAV.git %QTAV_DIR%
+::version freeze until fix of https://github.com/wang-bin/QtAV/issues/1149
+cd "%QTAV_DIR%" && git reset --hard 34afa14
+cd %QTAV_DIR%\..\ && cmd /c "%QTAV_DIR%\tools\ci\win\install_dep.bat"
+cd "%QTAV_DIR%"
+qmake QtAV.pro "CONFIG+=%configuration%" "CONFIG+=no-examples" "CONFIG+=no-tests"
+nmake %configuration%
+:goto install
+
+:installdeps
+cd %QTAV_DIR%\..\ && cmd /c "%QTAV_DIR%\tools\ci\win\install_dep.bat"
+
+:install
+call "%QTAV_DIR%\sdk_install.bat"


### PR DESCRIPTION
This PR adds two builds to appveyor (mpv and qtmultimedia). Also compiles openssl now, since before the dlls were linked against the visual runtime 2013, which was included not in the installer.
All the dependencies are cached, and only recompiled if their batch file is changed.
appveyor: https://ci.appveyor.com/project/mrgreywater/orion

Would be nice to have a github release after this, since the last windows release on github that works for me was 1.6.0 beta.