### PR TITLE
Fix HiDPI using QT_AUTO_SCREEN_SCALE_FACTOR

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,9 @@ int main(int argc, char *argv[])
     //Override QT_QUICK_CONTROLS_STYLE environment variable
     qputenv("QT_QUICK_CONTROLS_STYLE", "material");
 
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    if (!qEnvironmentVariableIsEmpty("QT_AUTO_SCREEN_SCALE_FACTOR")) {
+        QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    }
 
     auto opengl = SettingsManager::getInstance()->opengl().toLower();
 


### PR DESCRIPTION
By default orion renders at this size:
![gnome-shell-screenshot-5bkwwz](https://user-images.githubusercontent.com/14058972/52147964-5228b600-2636-11e9-8670-cf430d3a15bf.png)

This patch fixes the interface scaling on HiDPI displays:
![gnome-shell-screenshot-hduywz](https://user-images.githubusercontent.com/14058972/52147990-5ce34b00-2636-11e9-83ba-12c4c5b37bd7.png)

Setting `QT_AUTO_SCREEN_SCALE_FACTOR=1` will render the interface back to its original scaling size. I personally run orion with `env QT_SCALE_FACTOR=1.25 orion`

Thanks for this software!