### PR TITLE
add broadcaster, vips chat users list sections; add unrecognized sections automatically

### DIFF
--- a/src/qml/irc/ViewerList.qml
+++ b/src/qml/irc/ViewerList.qml
@@ -45,7 +45,22 @@ Item {
             target: Viewers
             onChatterListLoaded: {
                 root.loading = false;
-                var groupOrder = ["staff", "global_mods", "admins", "moderators", "viewers"];
+                var standardGroupOrder = ["broadcaster", "staff", "global_mods", "admins", "moderators", "vips", "viewers"];
+                var extraGroupsPos = standardGroupOrder.indexOf("moderators") + 1;
+
+                var extraGroups = [];
+
+                for (var otherGroupName in chatters) {
+                    if (standardGroupOrder.indexOf(otherGroupName) == -1) {
+                        extraGroups.push(otherGroupName)
+                    }
+                }
+                extraGroups.sort();
+
+                //var groupOrder = standardGroupOrder.slice();
+                //groupOrder.splice.apply([extraGroupsPos, 0].concat(extraGroups));
+                var groupOrder = standardGroupOrder.slice(0, extraGroupsPos).concat(extraGroups, standardGroupOrder.slice(extraGroupsPos));
+
 
                 var viewers = []
                 for (var j = 0; j < groupOrder.length; j++) {


### PR DESCRIPTION
The "Broadcaster" and "VIPs" sections were missing from the chat users list view so users in those categories were hidden in the users list.

I've added those categories in the usual positions they have in the Twitch web version's user lists. Also I've added some logic so that future new categories will at least be shown, in a consistent order, pending code changes to adjust the order to match whatever Twitch normally uses.