### PR TITLE
avoid just spinning forever when selected quality doesn't exist

### DIFF
--- a/src/qml/PlayerView.qml
+++ b/src/qml/PlayerView.qml
@@ -128,13 +128,27 @@ Page {
 
 
     function loadAndPlay(){
-        if (!streamMap) return
+        if (!streamMap) {
+            console.log("streamMap not available yet");
+            return;
+        }
 
         var description = setWatchingTitle();
 
         var start = !isVod ? -1 : seekBar.value
 
-        var url = streamMap[Settings.quality]
+        var quality = Settings.quality;
+        if (!streamMap.hasOwnProperty(quality)) {
+            console.log("no stream for quality", quality);
+            quality = "source";
+            console.log("using", quality);
+        }
+        var url = streamMap[quality]
+
+        if (url == null) {
+            console.error("did not have a playback url");
+            return;
+        }
 
         console.debug("Loading: ", url)
 


### PR DESCRIPTION
Addresses the spinning forever when there is no stream for the selected quality mentioned in #292 

- if the selected stream or VOD doesn't have the quality from the settings (e.g. the last quality manually set with the dropdown), try "source" instead
- if for whatever reason we still get a null URL, don't try playing the null UR, and log an error