### PR TITLE
chat emotes not initializing workaround

### DIFF
--- a/src/qml/irc/ChatView.qml
+++ b/src/qml/irc/ChatView.qml
@@ -280,6 +280,10 @@ Page {
             }
 
             function lookupEmote(word) {
+                if (_textEmotesMap == null) {
+                    console.log("FIXME: emotes haven't initialized");
+                    return;
+                }
                 var emoteId = _textEmotesMap[word];
                 if (emoteId != null) {
                     return emoteId;


### PR DESCRIPTION
A quick workaround for not being able to send chat messages when the frontend's emotes have failed to initialize for whatever reason